### PR TITLE
Updated branch name to main in workflow

### DIFF
--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -7,7 +7,7 @@ on:
       - '*'
   pull_request:
     branches:
-      - preview
+      - main
 
 env:
   ACTION_LINK: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - preview
+      - main
   pull_request:
     branches:
-      - preview
+      - main
 
 permissions:
   id-token: write # Required for requesting the JWT


### PR DESCRIPTION
The default branch is renamed to `main`.
