### PR TITLE
Enable LFS on deploy

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          lfs: true
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Update GitHub action to checkout repo with LFS enabled. This will enable the videos to be checked out and deployed.