### PR TITLE
Make Media Coverage a top-level side menu page

### DIFF
--- a/docs/content/community/media-coverage.md
+++ b/docs/content/community/media-coverage.md
@@ -2,7 +2,7 @@
 type: "docs"
 title: "Media Coverage"
 linkTitle: "Media Coverage"
-weight: 20
+weight: 90
 toc_hide: false
 hide_summary: false
 description: >


### PR DESCRIPTION
Moves Media Coverage from uunder Community to a top-level menu item