### PR TITLE
Add Docker resource requirements to dev container setup docs

### DIFF
--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -82,10 +82,26 @@ To use the Drasi Getting Started Dev Container, you will need to install:
 - Visual Studio Code [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 - [docker](https://www.docker.com/get-started/)
 
+#### Recommended Docker Resources
+
+For optimal performance with the Drasi Dev Container, we recommend configuring Docker with the following minimum resources:
+
+- **CPU**: 3 cores or more
+- **Memory**: 4 GB or more
+- **Swap**: 1 GB or more
+- **Disk**: 272 GB available space 
+
+To adjust these settings in Docker Desktop:
+1. Open Docker Desktop
+2. Go to Settings (gear icon)
+3. Navigate to "Resources" → "Advanced"
+4. Adjust the sliders to meet or exceed the recommended values
+5. Click "Apply & Restart"
+
 Once you have these prerequisites installed:
 1. Download the [Drasi Getting Started Tutorial ZIP file](https://github.com/drasi-project/learning/releases/download/0.1.1/quickstart-dev-container.zip), which contains the files you will need during the tutorial.
-1. Unzip the Drasi Getting Started Tutorial ZIP file to a suitable location on your computer
-1. Run VS Code and open the `tutorial/getting-started` folder from the Drasi Getting Started Tutorial files you just unzipped
+2. Unzip the Drasi Getting Started Tutorial ZIP file to a suitable location on your computer
+3. Run VS Code and open the `tutorial/getting-started` folder from the Drasi Getting Started Tutorial files you just unzipped
 
 If you have opened the correct folder, in the VS Code Explorer panel you will see two folders:
 - `.devcontainer` contains files that VS Code requires to configure the Dev Container

--- a/docs/content/tutorials/absence-of-change/_index.md
+++ b/docs/content/tutorials/absence-of-change/_index.md
@@ -43,6 +43,22 @@ Next, [clone the learning repo from Github](https://github.com/drasi-project/lea
   and open the repo in VS Code. Make sure that Docker daemon
   (or Docker Desktop) is running.
 
+#### Recommended Docker Resources
+
+For optimal performance with the Drasi Dev Container, we recommend configuring Docker with the following minimum resources:
+
+- **CPU**: 3 cores or more
+- **Memory**: 4 GB or more
+- **Swap**: 1 GB or more
+- **Disk**: 272 GB available space 
+
+To adjust these settings in Docker Desktop:
+1. Open Docker Desktop
+2. Go to Settings (gear icon)
+3. Navigate to "Resources" → "Advanced"
+4. Adjust the sliders to meet or exceed the recommended values
+5. Click "Apply & Restart"
+
 Once the solution is open in VS Code, follow these steps:
 - Press Cmd + Shift + P (on MacOS) or Ctrl + Shift + P (Windows or Linux) to
     launch the command palette.

--- a/docs/content/tutorials/building-comfort/_index.md
+++ b/docs/content/tutorials/building-comfort/_index.md
@@ -258,6 +258,23 @@ Next, [clone the learning repo from Github](https://github.com/drasi-project/lea
   and open the repo in VS Code. Make sure that Docker daemon
   (or Docker Desktop) is running.
 
+#### Recommended Docker Resources
+
+For optimal performance with the Drasi Dev Container, we recommend configuring Docker with the following minimum resources:
+
+- **CPU**: 3 cores or more
+- **Memory**: 4 GB or more
+- **Swap**: 1 GB or more
+- **Disk**: 272 GB available space 
+
+To adjust these settings in Docker Desktop:
+1. Open Docker Desktop
+2. Go to Settings (gear icon)
+3. Navigate to "Resources" → "Advanced"
+4. Adjust the sliders to meet or exceed the recommended values
+5. Click "Apply & Restart"
+
+
 Once the solution is open in VS Code, follow these steps:
 - Press Cmd + Shift + P (on MacOS) or Ctrl + Shift + P (Windows or Linux) to
     launch the command palette.

--- a/docs/content/tutorials/risky-containers/_index.md
+++ b/docs/content/tutorials/risky-containers/_index.md
@@ -47,6 +47,22 @@ Next, [clone the learning repo from Github](https://github.com/drasi-project/lea
   and open the repo in VS Code. Make sure that Docker daemon
   (or Docker Desktop) is running.
 
+#### Recommended Docker Resources
+
+For optimal performance with the Drasi Dev Container, we recommend configuring Docker with the following minimum resources:
+
+- **CPU**: 3 cores or more
+- **Memory**: 4 GB or more
+- **Swap**: 1 GB or more
+- **Disk**: 272 GB available space 
+
+To adjust these settings in Docker Desktop:
+1. Open Docker Desktop
+2. Go to Settings (gear icon)
+3. Navigate to "Resources" → "Advanced"
+4. Adjust the sliders to meet or exceed the recommended values
+5. Click "Apply & Restart"
+
 Once the solution is open in VS Code, follow these steps:
 - Press Cmd + Shift + P (on MacOS) or Ctrl + Shift + P (Windows or Linux) to
     launch the command palette.


### PR DESCRIPTION
This PR adds recommended Docker resource allocation section to dev container documentation for our tutorials. Currently, a section was added to the building comfort, risy container, absense of change and getting start tutorials. I was able to go through these tutorials smoothly with this config. It would be great if people could do some testing with these resource configs to see if things work well.

I did not add a section for the curbside pickup tutorial yet, as I know that Aman is working on it at the moment. I'll add that section once this tutorial is updated