### PR TITLE
Updated the installation command docs with details on how to fix sudo-related issues

### DIFF
--- a/docs/content/how-to-guides/installation/install-on-aks/_index.md
+++ b/docs/content/how-to-guides/installation/install-on-aks/_index.md
@@ -24,36 +24,8 @@ On the computer which you will use to install Drasi, you need to install the fol
 - [Azure CLI](https://learn.microsoft.com//cli/azure/install-azure-cli)
 
 ## Get the Drasi CLI
-You will install Drasi on the AKS cluster using the [Drasi CLI](/reference/command-line-interface/). 
 
-You can get the Drasi CLI for your platform using one of the following options:
-
-{{< tabpane >}}
-{{< tab header="macOS" lang="bash" >}}
-curl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash
-{{< /tab >}}
-{{< tab header="Windows PowerShell" lang="powershell" >}}
-iwr -useb "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.ps1" | iex
-{{< /tab >}}
-{{< tab header="Linux" lang="shell" >}}
-wget -q "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh" -O - | /bin/bash
-{{< /tab >}}
-{{% tab header="Binaries" text=true %}}
-Download a specific version of the CLI from the [drasi-platform releases](https://github.com/drasi-project/drasi-platform/releases) page on GitHub. The file to download for your platform is:
-- **macOS arm64** - drasi-darwin-arm64
-- **macOS x64** - drasi-darwin-x64
-- **Windows x64** - drasi-windows-x64.exe
-- **Linux x64** - drasi-linux-x64
-- **Linux arm64** - drasi-linux-arm64
-
-Once downloaded, rename the file to `drasi` (macOS and Linux) or `drasi.exe` (Windows) and add it to your path.
-{{% /tab %}}
-{{% tab header="Build from Source" text=true %}}
-The Drasi CLI source code is in the [drasi-platform repo](https://github.com/drasi-project/drasi-platform) in the [cli folder](https://github.com/drasi-project/drasi-platform/tree/main/cli).
-
-The [readme.md](https://github.com/drasi-project/drasi-platform/blob/main/cli/README.md) file in the `cli` folder describes how to build and install the Drasi CLI on your computer.
-{{% /tab %}}
-{{< /tabpane >}}
+{{< read file= "/shared-content/installation/drasi-cli/cli-installation.md" >}}
 
 This guide focuses on how to install Drasi on an AKS cluster and covers only a few features of the Drasi CLI. Refer to the [Drasi CLI Command Reference](/reference/command-line-interface/#command-reference) for a complete description of the functionality it provides.
 

--- a/docs/content/how-to-guides/installation/install-on-docker/_index.md
+++ b/docs/content/how-to-guides/installation/install-on-docker/_index.md
@@ -15,36 +15,7 @@ On the computer where you will install Drasi, you need to install [Docker](https
 
 
 ## Get the Drasi CLI
-You will install Drasi using the [Drasi CLI](/reference/command-line-interface/). 
-
-You can get the Drasi CLI for your platform using one of the following options:
-
-{{< tabpane >}}
-{{< tab header="macOS" lang="bash" >}}
-curl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash
-{{< /tab >}}
-{{< tab header="Windows PowerShell" lang="powershell" >}}
-iwr -useb "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.ps1" | iex
-{{< /tab >}}
-{{< tab header="Linux" lang="shell" >}}
-wget -q "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh" -O - | /bin/bash
-{{< /tab >}}
-{{% tab header="Binaries" text=true %}}
-Download a specific version of the CLI from the [drasi-platform releases](https://github.com/drasi-project/drasi-platform/releases) page on GitHub. The file to download for your platform is:
-- **macOS arm64** - drasi-darwin-arm64
-- **macOS x64** - drasi-darwin-x64
-- **Windows x64** - drasi-windows-x64.exe
-- **Linux x64** - drasi-linux-x64
-- **Linux arm64** - drasi-linux-arm64
-
-Once downloaded, rename the file to `drasi` (macOS and Linux) or `drasi.exe` (Windows) and add it to your path.
-{{% /tab %}}
-{{% tab header="Build from Source" text=true %}}
-The Drasi CLI source code is in the [drasi-platform repo](https://github.com/drasi-project/drasi-platform) in the [cli folder](https://github.com/drasi-project/drasi-platform/tree/main/cli).
-
-The [readme.md](https://github.com/drasi-project/drasi-platform/blob/main/cli/README.md) file in the `cli` folder describes how to build and install the Drasi CLI on your computer.
-{{% /tab %}}
-{{< /tabpane >}}
+{{< read file= "/shared-content/installation/drasi-cli/cli-installation.md" >}}
 
 ## Install Drasi as a Docker container
 To install Drasi as a Docker container using all default settings, simply run the command:

--- a/docs/content/how-to-guides/installation/install-on-eks/_index.md
+++ b/docs/content/how-to-guides/installation/install-on-eks/_index.md
@@ -127,38 +127,7 @@ kubectl config use-context <your cluster name>
 ```
 
 ## Get the Drasi CLI
-You will install Drasi on the EKS cluster using the [Drasi CLI](/reference/command-line-interface/). This guide focuses on how to install Drasi on an EKS cluster and covers only a few features of the Drasi CLI. Refer to the [Drasi CLI Command Reference](/reference/command-line-interface/#command-reference) for a complete description of the functionality it provides.
-
-You can get the Drasi CLI for your platform using one of the following options:
-
-{{< tabpane >}}
-{{< tab header="macOS" lang="bash" >}}
-curl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash
-{{< /tab >}}
-{{< tab header="Windows PowerShell" lang="powershell" >}}
-iwr -useb "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.ps1" | iex
-{{< /tab >}}
-{{< tab header="Linux" lang="shell" >}}
-wget -q "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh" -O - | /bin/bash
-{{< /tab >}}
-{{% tab header="Binaries" text=true %}}
-Download a specific version of the CLI from the [drasi-platform releases](https://github.com/drasi-project/drasi-platform/releases) page on GitHub. The file to download for your platform is:
-- **macOS arm64** - drasi-darwin-arm64
-- **macOS x64** - drasi-darwin-x64
-- **Windows x64** - drasi-windows-x64.exe
-- **Linux x64** - drasi-linux-x64
-- **Linux arm64** - drasi-linux-arm64
-
-Once downloaded, rename the file to `drasi` (macOS and Linux) or `drasi.exe` (Windows) and add it to your path.
-{{% /tab %}}
-{{% tab header="Build from Source" text=true %}}
-The Drasi CLI source code is in the [drasi-platform repo](https://github.com/drasi-project/drasi-platform) in the [cli folder](https://github.com/drasi-project/drasi-platform/tree/main/cli).
-
-The [readme.md](https://github.com/drasi-project/drasi-platform/blob/main/cli/README.md) file in the `cli` folder describes how to build and install the Drasi CLI on your computer.
-{{% /tab %}}
-{{< /tabpane >}}
-
-
+{{< read file= "/shared-content/installation/drasi-cli/cli-installation.md" >}}
 
 ## Install Drasi on the EKS Cluster
 Before installing Drasi, ensure that your kubectl context is set to the EKS cluster where you want to install Drasi. Then, configure a new Drasi CLI environment by running the following command:

--- a/docs/content/how-to-guides/installation/install-on-k3s/_index.md
+++ b/docs/content/how-to-guides/installation/install-on-k3s/_index.md
@@ -57,36 +57,7 @@ kubectl cluster-info
 This will create a k3s cluster named **k3d-k3s-default** and set the current kubectl context to the new cluster. Now you can manage the k3s cluster using familiar Kubernetes management tools such as kubectl and the [Kubernetes extension](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) for [Visual Studio Code](https://code.visualstudio.com/).
 
 ## Get the Drasi CLI
-You will install Drasi on the k3s cluster using the [Drasi CLI](/reference/command-line-interface/). 
-
-You can get the Drasi CLI for your platform using one of the following options:
-
-{{< tabpane >}}
-{{< tab header="macOS" lang="bash" >}}
-curl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash
-{{< /tab >}}
-{{< tab header="Windows PowerShell" lang="powershell" >}}
-iwr -useb "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.ps1" | iex
-{{< /tab >}}
-{{< tab header="Linux" lang="shell" >}}
-wget -q "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh" -O - | /bin/bash
-{{< /tab >}}
-{{% tab header="Binaries" text=true %}}
-Download a specific version of the CLI from the [drasi-platform releases](https://github.com/drasi-project/drasi-platform/releases) page on GitHub. The file to download for your platform is:
-- **macOS arm64** - drasi-darwin-arm64
-- **macOS x64** - drasi-darwin-x64
-- **Windows x64** - drasi-windows-x64.exe
-- **Linux x64** - drasi-linux-x64
-- **Linux arm64** - drasi-linux-arm64
-
-Once downloaded, rename the file to `drasi` (macOS and Linux) or `drasi.exe` (Windows) and add it to your path.
-{{% /tab %}}
-{{% tab header="Build from Source" text=true %}}
-The Drasi CLI source code is in the [drasi-platform repo](https://github.com/drasi-project/drasi-platform) in the [cli folder](https://github.com/drasi-project/drasi-platform/tree/main/cli).
-
-The [readme.md](https://github.com/drasi-project/drasi-platform/blob/main/cli/README.md) file in the `cli` folder describes how to build and install the Drasi CLI on your computer.
-{{% /tab %}}
-{{< /tabpane >}}
+{{< read file= "/shared-content/installation/drasi-cli/cli-installation.md" >}}
 
 This guide focuses on how to install Drasi on a k3s cluster and covers only a few features of the Drasi CLI. Refer to the [Drasi CLI Command Reference](/reference/command-line-interface/#command-reference) for a complete description of the functionality it provides.
 

--- a/docs/content/how-to-guides/installation/install-on-kind/_index.md
+++ b/docs/content/how-to-guides/installation/install-on-kind/_index.md
@@ -45,36 +45,7 @@ kubectl cluster-info --context kind-kind
 This will create a kind cluster named **kind-kind** and set the current kubectl context to the new cluster. Now you can manage the kind cluster using familiar Kubernetes management tools such as kubectl and the [Kubernetes extension](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) for [Visual Studio Code](https://code.visualstudio.com/).
 
 ## Get the Drasi CLI
-You will install Drasi on the kind cluster using the [Drasi CLI](/reference/command-line-interface/). 
-
-You can get the Drasi CLI for your platform using one of the following options:
-
-{{< tabpane >}}
-{{< tab header="macOS" lang="bash" >}}
-curl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash
-{{< /tab >}}
-{{< tab header="Windows PowerShell" lang="powershell" >}}
-iwr -useb "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.ps1" | iex
-{{< /tab >}}
-{{< tab header="Linux" lang="shell" >}}
-wget -q "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh" -O - | /bin/bash
-{{< /tab >}}
-{{% tab header="Binaries" text=true %}}
-Download a specific version of the CLI from the [drasi-platform releases](https://github.com/drasi-project/drasi-platform/releases) page on GitHub. The file to download for your platform is:
-- **macOS arm64** - drasi-darwin-arm64
-- **macOS x64** - drasi-darwin-x64
-- **Windows x64** - drasi-windows-x64.exe
-- **Linux x64** - drasi-linux-x64
-- **Linux arm64** - drasi-linux-arm64
-
-Once downloaded, rename the file to `drasi` (macOS and Linux) or `drasi.exe` (Windows) and add it to your path.
-{{% /tab %}}
-{{% tab header="Build from Source" text=true %}}
-The Drasi CLI source code is in the [drasi-platform repo](https://github.com/drasi-project/drasi-platform) in the [cli folder](https://github.com/drasi-project/drasi-platform/tree/main/cli).
-
-The [readme.md](https://github.com/drasi-project/drasi-platform/blob/main/cli/README.md) file in the `cli` folder describes how to build and install the Drasi CLI on your computer.
-{{% /tab %}}
-{{< /tabpane >}}
+{{< read file= "/shared-content/installation/drasi-cli/cli-installation.md" >}}
 
 This guide focuses on how to install Drasi on a kind cluster and covers only a few features of the Drasi CLI. Refer to the [Drasi CLI Command Reference](/reference/command-line-interface/#command-reference) for a complete description of the functionality it provides.
 

--- a/docs/content/how-to-guides/installation/install-using-manifests/_index.md
+++ b/docs/content/how-to-guides/installation/install-using-manifests/_index.md
@@ -24,34 +24,7 @@ You will need:
 
 You will generate the manifests using the [Drasi CLI](/reference/command-line-interface/). 
 
-You can get the Drasi CLI for your platform using one of the following options:
-
-{{< tabpane >}}
-{{< tab header="macOS" lang="bash" >}}
-curl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash
-{{< /tab >}}
-{{< tab header="Windows PowerShell" lang="powershell" >}}
-iwr -useb "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.ps1" | iex
-{{< /tab >}}
-{{< tab header="Linux" lang="shell" >}}
-wget -q "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh" -O - | /bin/bash
-{{< /tab >}}
-{{% tab header="Binaries" text=true %}}
-Download a specific version of the CLI from the [drasi-platform releases](https://github.com/drasi-project/drasi-platform/releases) page on GitHub. The file to download for your platform is:
-- **macOS arm64** - drasi-darwin-arm64
-- **macOS x64** - drasi-darwin-x64
-- **Windows x64** - drasi-windows-x64.exe
-- **Linux x64** - drasi-linux-x64
-- **Linux arm64** - drasi-linux-arm64
-
-Once downloaded, rename the file to `drasi` (macOS and Linux) or `drasi.exe` (Windows) and add it to your path.
-{{% /tab %}}
-{{% tab header="Build from Source" text=true %}}
-The Drasi CLI source code is in the [drasi-platform repo](https://github.com/drasi-project/drasi-platform) in the [cli folder](https://github.com/drasi-project/drasi-platform/tree/main/cli).
-
-The [readme.md](https://github.com/drasi-project/drasi-platform/blob/main/cli/README.md) file in the `cli` folder describes how to build and install the Drasi CLI on your computer.
-{{% /tab %}}
-{{< /tabpane >}}
+{{< read file= "/shared-content/installation/drasi-cli/cli-installation.md" >}}
 
 ## Generate Drasi Manifests
 

--- a/docs/content/reference/command-line-interface/_index.md
+++ b/docs/content/reference/command-line-interface/_index.md
@@ -37,34 +37,8 @@ drasi list query
 ```
 
 ## Get the Drasi CLI
-You can get the Drasi CLI for your platform using one of the following options:
 
-{{< tabpane >}}
-{{< tab header="macOS" lang="bash" >}}
-curl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash
-{{< /tab >}}
-{{< tab header="Windows PowerShell" lang="powershell" >}}
-iwr -useb "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.ps1" | iex
-{{< /tab >}}
-{{< tab header="Linux" lang="shell" >}}
-wget -q "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh" -O - | /bin/bash
-{{< /tab >}}
-{{% tab header="Binaries" text=true %}}
-Download a specific version of the CLI from the [drasi-platform releases](https://github.com/drasi-project/drasi-platform/releases) page on GitHub. The file to download for your platform is:
-- **macOS arm64** - drasi-darwin-arm64
-- **macOS x64** - drasi-darwin-x64
-- **Windows x64** - drasi-windows-x64.exe
-- **Linux x64** - drasi-linux-x64
-- **Linux arm64** - drasi-linux-arm64
-
-Once downloaded, rename the file to `drasi` (macOS and Linux) or `drasi.exe` (Windows) and add it to your path.
-{{% /tab %}}
-{{% tab header="Build from Source" text=true %}}
-The Drasi CLI source code is in the [drasi-platform repo](https://github.com/drasi-project/drasi-platform) in the [cli folder](https://github.com/drasi-project/drasi-platform/tree/main/cli).
-
-The [readme.md](https://github.com/drasi-project/drasi-platform/blob/main/cli/README.md) file in the `cli` folder describes how to build and install the Drasi CLI on your computer.
-{{% /tab %}}
-{{< /tabpane >}}
+{{< read file= "/shared-content/installation/drasi-cli/cli-installation.md" >}}
 
 ## Get Help
 The Drasi CLI provides online help for the different commands it supports and the arguments each command accepts. If you run `drasi` from the command line, you will see the following output providing a high level overview of all the commands supported by the Drasi CLI:

--- a/docs/layouts/shortcodes/read.html
+++ b/docs/layouts/shortcodes/read.html
@@ -1,0 +1,3 @@
+{{ $file := .Get "file" }}
+{{ $fileContents := $file | readFile }}
+{{ (print "\n" $fileContents "\n") | markdownify }}

--- a/docs/shared-content/installation/drasi-cli/cli-installation.md
+++ b/docs/shared-content/installation/drasi-cli/cli-installation.md
@@ -1,0 +1,35 @@
+You can get the Drasi CLI for your platform using one of the following options:
+
+{{< tabpane >}}
+{{< tab header="macOS" lang="bash" >}}
+curl -fsSL https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh | /bin/bash
+{{< /tab >}}
+{{< tab header="Windows PowerShell" lang="powershell" >}}
+iwr -useb "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.ps1" | iex
+{{< /tab >}}
+{{< tab header="Linux" lang="shell" >}}
+wget -q "https://raw.githubusercontent.com/drasi-project/drasi-platform/main/cli/installers/install-drasi-cli.sh" -O - | /bin/bash
+{{< /tab >}}
+{{% tab header="Binaries" text=true %}}
+Download a specific version of the CLI from the [drasi-platform releases](https://github.com/drasi-project/drasi-platform/releases) page on GitHub. The file to download for your platform is:
+- **macOS arm64** - drasi-darwin-arm64
+- **macOS x64** - drasi-darwin-x64
+- **Windows x64** - drasi-windows-x64.exe
+- **Linux x64** - drasi-linux-x64
+- **Linux arm64** - drasi-linux-arm64
+
+Once downloaded, rename the file to `drasi` (macOS and Linux) or `drasi.exe` (Windows) and add it to your path.
+{{% /tab %}}
+{{% tab header="Build from Source" text=true %}}
+The Drasi CLI source code is in the [drasi-platform repo](https://github.com/drasi-project/drasi-platform) in the [cli folder](https://github.com/drasi-project/drasi-platform/tree/main/cli).
+
+The [readme.md](https://github.com/drasi-project/drasi-platform/blob/main/cli/README.md) file in the `cli` folder describes how to build and install the Drasi CLI on your computer.
+{{% /tab %}}
+{{< /tabpane >}}
+
+> If you encounter sudo-related errors during installation (such as "no new privileges" flag restrictions in certain containerized or restricted environments), you can install the Drasi CLI to a user directory instead of the default system-wide location. Set the DRASI_INSTALL_DIR environment variable to a directory in your home folder before running the installation script. Below is the sample script for Linux:
+> ```bash
+> export DRASI_INSTALL_DIR="$HOME/.local/bin"
+> mkdir -p "$HOME/.local/bin"
+> # Execute the installation command
+> ```


### PR DESCRIPTION
Sometimes the Linux installation command would fail due to sudo-related issue. This PR updates our CLI installation docs with instructions for fixing this issue.
Additionally, this pull request refactors the documentation for installing the Drasi CLI across multiple guides by centralizing the CLI installation instructions into a single shared content file. Instead of duplicating the installation steps in each guide, the documentation now uses a Hugo shortcode to include the shared instructions, making future maintenance easier and ensuring consistency.
