### PR TITLE
Docs for SQLServer managed identity config

### DIFF
--- a/.github/config/en-drasi.txt
+++ b/.github/config/en-drasi.txt
@@ -212,3 +212,4 @@ webhook
 baseUrl
 backticks
 unescaped
+JDBC

--- a/docs/content/how-to-guides/configure-sources/configure-mssql-source/_index.md
+++ b/docs/content/how-to-guides/configure-sources/configure-mssql-source/_index.md
@@ -155,7 +155,7 @@ When using the `MicrosoftEntraWorkloadID` identity, you must also set `authentic
 1. Ensure `Enable Workload Identity` is enabled.
 1. Take note of the `Issuer URL` under OIDC.
 1. Create or use an existing `User Assigned Managed Identity`.
-1. Take note of the `Client ID` an the `Overview` pane of the Managed Identity.
+1. Take note of the `Client ID` on the `Overview` pane of the Managed Identity.
 1. Grant the `Reader` role of the SQL Server to the managed identity in the `Azure role assignments` pane of the managed identity.
 1. Create a federated credential between the managed identity and the source.
     ```bash


### PR DESCRIPTION
This pull request updates the SQL Server source configuration documentation to add support for authentication using Microsoft Entra Workload Identity (Managed Identity) in Azure environments. The documentation now includes details on configuring the source for managed identity authentication, step-by-step AKS setup instructions, and guidance for granting SQL permissions.

**Authentication and Identity Configuration:**
* Added documentation for the `authentication` property in the SQL Server source configuration, explaining how to use `ActiveDirectoryManagedIdentity` for managed identities and when to omit it for username/password authentication.
* Introduced a new `identity` section under the source `spec`, describing how to configure Microsoft Entra Workload Identity, including the required properties (`kind`, `clientId`) and a YAML example.

**Azure AKS and SQL Setup Instructions:**
* Provided detailed AKS setup steps for enabling Workload Identity, creating managed identities, assigning roles, and creating federated credentials for the source.
* Added SQL commands for creating an external user for the managed identity and granting it read permissions on the database.

**Reference Links:**
* Included related links to official Microsoft documentation for managed identities, workload identities, and AKS setup for further reading.