### PR TITLE
previousValue + previousDistinctValue function docs

### DIFF
--- a/.github/config/en-custom.txt
+++ b/.github/config/en-custom.txt
@@ -1523,4 +1523,5 @@ ecommerce
 catalogue
 ImhYfLplM
 beforeChange
+previousValue
 previousDistinctValue

--- a/docs/content/reference/query-language/drasi-custom-functions.md
+++ b/docs/content/reference/query-language/drasi-custom-functions.md
@@ -14,7 +14,7 @@ Drasi is not simply running graph queries across data, it is using the Cypher Qu
 | **[METADATA FUNCTIONS](#drasi-metadata-functions)** ||
 | [drasi.changeDateTime](#drasichangedatetime) | Gets a ZONED DATETIME of when a specified element was changed |
 | **[DELTA FUNCTIONS](#drasi-delta-functions)** ||
-| [drasi.beforeChange](#drasibeforechange) | Gets the value of an expression within a query as it was before the current change |
+| [drasi.previousValue](#drasipreviousvalue) | Gets the value of an expression within a query as it was before the current change |
 | [drasi.previousDistinctValue](#drasipreviousdistinctvalue) | Gets the previous value of an expression within a query that was different from the current value  |
 | **[LIST FUNCTIONS](#drasi-list-functions)** ||
 | [drasi.listMin](#drasilistmin)  | Returns the minimum value contained in a LIST |
@@ -54,12 +54,12 @@ The `drasi.changeDateTime` function returns a ZONED DATETIME.
 
 ## Drasi DELTA Functions
 
-### drasi.beforeChange()
-The `drasi.beforeChange` function returns the value of an expression within a query as it was before the current change.
+### drasi.previousValue()
+The `drasi.previousValue` function returns the value of an expression within a query as it was before the current change.
 
 #### Syntax
 ```cypher
-drasi.beforeChange(expression, default)
+drasi.previousValue(expression, default)
 ```
 
 #### Arguments
@@ -71,14 +71,14 @@ drasi.beforeChange(expression, default)
 
 #### Returns
 
-The `drasi.beforeChange` function returns the value of the given expression as it was before the current change.
+The `drasi.previousValue` function returns the value of the given expression as it was before the current change.
 
 #### Example
 
 For example, if we wanted to know when any `Task` changes from the `pending` state to the `active` state. This could be achieved with the following clause:
 
 ```sql
-WHERE t.state = 'active' AND drasi.beforeChange(t.state) = 'pending'
+WHERE t.state = 'active' AND drasi.previousValue(t.state) = 'pending'
 ```
 
 In this case:


### PR DESCRIPTION
This pull request reorganizes and expands the documentation for Drasi custom functions in the `docs/content/reference/query-language/drasi-custom-functions.md` file. The changes introduce clearer grouping of functions by theme, add detailed explanations and examples for new and existing functions, and improve consistency in formatting. This makes it easier for users to understand the purpose and usage of each function.

**Function grouping and documentation improvements:**

* Functions are now grouped into METADATA, DELTA, LIST, TEMPORAL, FUTURE, and STATISTICAL sections, with clear headings and navigation links for each group.
* Detailed documentation was added for new DELTA functions: `drasi.previousValue` and `drasi.previousDistinctValue`, including syntax, arguments, return values, and practical examples.

**Formatting and consistency enhancements:**

* All function documentation now uses consistent headings, argument tables, and return value sections for improved readability.
* Example queries and explanations have been included for key functions to illustrate their use in real scenarios.

**Content updates and corrections:**

* The `drasi.changeDateTime` function was moved from TEMPORAL to METADATA, reflecting its actual purpose. [[1]](diffhunk://#diff-607a9fac40080eb7e95bd5d8da9f2a8e08baf4c2682ed9542639e1466255fd14R14-L18) [[2]](diffhunk://#diff-607a9fac40080eb7e95bd5d8da9f2a8e08baf4c2682ed9542639e1466255fd14L28-R210)
* The requirement for a temporal Element Index is clarified for TEMPORAL and FUTURE functions.
* Documentation for FUTURE and STATISTICAL functions was updated for clarity and completeness, including formal descriptions of return values and behavior. [[1]](diffhunk://#diff-607a9fac40080eb7e95bd5d8da9f2a8e08baf4c2682ed9542639e1466255fd14L143-R243) [[2]](diffhunk://#diff-607a9fac40080eb7e95bd5d8da9f2a8e08baf4c2682ed9542639e1466255fd14L177-R270) [[3]](diffhunk://#diff-607a9fac40080eb7e95bd5d8da9f2a8e08baf4c2682ed9542639e1466255fd14L207-R300) [[4]](diffhunk://#diff-607a9fac40080eb7e95bd5d8da9f2a8e08baf4c2682ed9542639e1466255fd14L239-R337)