### PR TITLE
Fix typo in Http Reaction examples

### DIFF
--- a/docs/content/how-to-guides/configure-reactions/configure-http-reaction/_index.md
+++ b/docs/content/how-to-guides/configure-reactions/configure-http-reaction/_index.md
@@ -35,7 +35,7 @@ spec:
     baseUrl: "https://api.example.com"
     token: "your-bearer-token"
   queries:
-    <query-id>:
+    <query-id>: >
       added:
         url: "/webhook/{{after.id}}"
         method: "POST"
@@ -135,7 +135,7 @@ spec:
     baseUrl: "https://api.github.com"
     token: "ghp_your_github_token_here"
   queries:
-    issue-comments:
+    issue-comments: >
       added:
         url: "/repos/{{after.repo}}/issues/{{after.issue_number}}/comments"
         method: "POST"


### PR DESCRIPTION
This pull request makes a minor formatting change to the YAML examples in the documentation for configuring HTTP reactions. The update clarifies the block scalar usage for query definitions.

* Documentation formatting:
  * Changed the `queries` section in the YAML examples to use the block scalar (`>`) for the `<query-id>` and `issue-comments` keys, improving readability and clarity in `docs/content/how-to-guides/configure-reactions/configure-http-reaction/_index.md`. [[1]](diffhunk://#diff-b2c6d7a4ee3b421dbe1c1d4cc9b075b8a63930f71c9b506af928501d6b836e12L38-R38) [[2]](diffhunk://#diff-b2c6d7a4ee3b421dbe1c1d4cc9b075b8a63930f71c9b506af928501d6b836e12L138-R138)