### PR TITLE
Add web.config to fix .yaml 404s on Azure App Service

### DIFF
--- a/docs/static/web.config
+++ b/docs/static/web.config
@@ -27,14 +27,5 @@
       <mimeMap fileExtension=".json" mimeType="application/json; charset=utf-8" />
       <mimeMap fileExtension=".webmanifest" mimeType="application/manifest+json" />
     </staticContent>
-
-    <caching>
-      <profile enabled="true" location="Client" duration="30.00:00:00">
-        <add extension=".yaml" policy="CacheForTimePeriod" duration="365.00:00:00" />
-        <add extension=".yml"  policy="CacheForTimePeriod" duration="365.00:00:00" />
-        <add extension=".json" policy="CacheForTimePeriod" duration="365.00:00:00" />
-      </profile>
-    </caching>
-
   </system.webServer>
 </configuration>


### PR DESCRIPTION
This shoudl allow us to access `drasi-context.yaml` at drasi.io/drasi-context.yaml