### PR TITLE
Document new collect() aggregating function

### DIFF
--- a/docs/content/reference/query-language/cypher.md
+++ b/docs/content/reference/query-language/cypher.md
@@ -45,7 +45,7 @@ Drasi currently supports the following subset of the Cypher Query Language:
     - elementId, head, last, timestamp
     - char_length, character_length, size
     - toInteger, toIntegerOrNull, toFloat, toFloatOrNull, toBoolean, toBooleanOrNull
-  - Aggregating: count, sum, avg, min, max in both WITH and RETURN clauses
+  - Aggregating: count, sum, avg, min, max, collect in both WITH and RETURN clauses
   - List: reduce, tail, range 
   - Numeric: abs, ceil, floor, rand, round, sign
   - String: left, ltrim, replace, reverse, right, rtrim, split, substring, toLower, toString, toStringOrNull, toUpper, trim

--- a/docs/content/reference/query-language/gql.md
+++ b/docs/content/reference/query-language/gql.md
@@ -1150,6 +1150,38 @@ MATCH (p:Product)
 RETURN max(p.price) AS highest_price
 ```
 
+#### Collect()
+The `collect` function aggregates values into a list. Null values are excluded.
+
+##### Syntax
+```gql
+collect(expression)
+```
+
+##### Arguments
+The `collect` function accepts one argument:
+
+| Name | Type | Description |
+|------|------|-------------|
+| expression | ANY | An expression whose non-null values will be collected into a list |
+
+##### Returns
+The `collect` function returns a LIST containing all non-null values. Duplicate values are preserved. The order of elements is not guaranteed.
+
+```gql
+MATCH (p:Product)<-[:REVIEWS]-(r:Review)
+RETURN p.name AS product, collect(r.rating) AS all_ratings
+```
+
+> **Performance Note:** Unlike scalar aggregations (`count()`, `sum()`, `avg()`, `min()`, `max()`) which maintain constant-size state regardless of collection size, `collect()` stores every value in the collection. This means memory usage and update overhead scale linearly with the number of items.
+>
+> **Practical guidelines:**
+> - **Up to ~100 items per group**: Generally appropriate with minimal performance impact
+> - **100-500 items**: Use with caution; only when collections are not frequently updated
+> - **500+ items**: Not recommended due to significant memory and performance impact
+>
+> If you only need derived values (count, sum, average, min, max), prefer the dedicated aggregation functions which are optimized for incremental updates.
+
 ### Temporal Functions
 
 Temporal functions work with date, time, and duration values.


### PR DESCRIPTION
  This documents the `collect()` function implemented in drasi-project/drasi-core#57

  - **cypher.md**: Added `collect` to the list of supported aggregating functions
  - **gql.md**: Added full documentation for `collect()` including:
    - Syntax and arguments
    - Return value description
    - Usage example
    - Performance guidelines for different collection sizes
