### PR TITLE
docs: fix grammar and typos in core documentation

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -9,7 +9,7 @@ description: >
 
 <div class="hero-section hero-section--compact">
   <h1 class="hero-title">Build Change-driven Solutions with Drasi</h1>
-  <p class="hero-subtitle">Drasi is a Data Change Processing platform that makes it easy build change-driven solutions that detect complex changes across your data sources and react to them instantly.</p>
+  <p class="hero-subtitle">Drasi is a Data Change Processing platform that makes it easy to build change-driven solutions that detect complex changes across your data sources and react to them instantly.</p>
 
   <div class="cta-group">
     <a href="/drasi-server/getting-started/" class="cta-button cta-button--primary">

--- a/docs/content/concepts/overview/_index.md
+++ b/docs/content/concepts/overview/_index.md
@@ -105,7 +105,7 @@ More detail about Sources is available in the [Sources](/concepts/sources) overv
 
 ### Continuous Queries
 
-Continuous Queries, as the name implies, are queries that run continuously. To understand what is unique about them, it is useful to contrast them with a the kind of {{< term "Instantaneous Query" "instantaneous queries" >}} developers are accustomed to running against databases. 
+Continuous Queries, as the name implies, are queries that run continuously. To understand what is unique about them, it is useful to contrast them with the kind of {{< term "Instantaneous Query" "instantaneous queries" >}} developers are accustomed to running against databases. 
 
 When you execute an **instantaneous query**, you are running the query against the database at a point in time. The database calculates the results to the query and returns them. While you work with those results, you are working with a static snapshot of the data and are unaware of any changes that may have happened to the data after you ran the query. If you run the same instantaneous query periodically, the query results might be different each time due to changes made to the data by other processes. But to understand what has changed, you would need to compare the most recent result with the previous result.
 

--- a/docs/content/drasi-kubernetes/how-to-guides/configure-reactions/configure-signalr-reaction/_index.md
+++ b/docs/content/drasi-kubernetes/how-to-guides/configure-reactions/configure-signalr-reaction/_index.md
@@ -305,7 +305,7 @@ npm install --save @drasi/signalr-react
 
 #### ResultSet Component
 
-The `ResultSet` component requires an endpoint to the SignalR reaction and a query ID. It will render a copy of it's children for every item in the result set of that query, and keep the data up to date via the SignalR connection.
+The `ResultSet` component requires an endpoint to the SignalR reaction and a query ID. It will render a copy of its children for every item in the result set of that query, and keep the data up to date via the SignalR connection.
 
 ```jsx
 <ResultSet url='<Your Drasi SignalR endpoint>' queryId='<query name>' sortBy={item => item.field1}>
@@ -359,7 +359,7 @@ npm install --save @drasi/signalr-vue
 
 #### ResultSet Component
 
-The `ResultSet` component requires an endpoint to the SignalR reaction and a query ID. It will render a copy of it's children for every item in the result set of that query, and keep the data up to date via the SignalR connection.
+The `ResultSet` component requires an endpoint to the SignalR reaction and a query ID. It will render a copy of its children for every item in the result set of that query, and keep the data up to date via the SignalR connection.
 
 ```vue
 <ResultSet url="<your signalr endpoint>" queryId="<query name>" :sortBy="item => item.field1">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "drasi-docs",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "drasi-docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This PR fixes a few minor grammar and typo issues in the core documentation files:
- Fixed missing "to" on the home page hero section.
- Removed a double article ("a the") in the Concepts Overview.
- Fixed possessive "its" vs "it's" in the SignalR reaction documentation.

These changes improve the overall clarity and professionalism of the documentation.
