### PR TITLE
Updated the download instructions for drasi-server-examples.zip

### DIFF
--- a/docs/content/drasi-server/getting-started/download-binary/_index.md
+++ b/docs/content/drasi-server/getting-started/download-binary/_index.md
@@ -31,11 +31,11 @@ There are a set files used during setup and the tutorial that you need to downlo
 
 {{< tabpane persist="header" >}}
 {{< tab header="Mac / Linux" lang="bash" >}}
-curl -fsSL https://github.com/drasi-project/drasi-server/releases/download/0.1.3/drasi-server-examples.zip -o drasi-server-examples.zip
+curl -fsSL https://github.com/drasi-project/drasi-server/releases/latest/download/drasi-server-examples.zip -o drasi-server-examples.zip
 unzip drasi-server-examples.zip -d .
 {{< /tab >}}
 {{< tab header="Windows" lang="powershell" >}}
-curl -fsSL https://github.com/drasi-project/drasi-server/releases/download/0.1.3/drasi-server-examples.zip -o drasi-server-examples.zip
+curl -fsSL https://github.com/drasi-project/drasi-server/releases/latest/download/drasi-server-examples.zip -o drasi-server-examples.zip
 tar -xf drasi-server-examples.zip
 {{< /tab >}}
 {{< /tabpane >}}


### PR DESCRIPTION
# Description

This pull request updates the download instructions for the `drasi-server-examples.zip` file in the getting started documentation. The instructions now always fetch the latest release instead of a hardcoded version, making it easier for users to get the most up-to-date examples.

Documentation improvements:

* Updated the download URLs in the setup instructions for both Mac/Linux and Windows to use the `latest` release of `drasi-server-examples.zip` from GitHub, instead of version `0.1.3`.
## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
