### PR TITLE
docs(drasi-server): use indicative versions and add binary verificati…

### DIFF
--- a/docs/content/drasi-server/getting-started/build-from-source/_index.md
+++ b/docs/content/drasi-server/getting-started/build-from-source/_index.md
@@ -93,12 +93,12 @@ Verify the `drasi-server` binary works:
 ./bin/drasi-server --version
 ```
 
-You should see output showing the version number, for example:
+You should see output showing the version number. The exact versions depend on which release of Drasi Server you have installed, so the numbers below are only examples. The latest release is always available from the <a href="https://github.com/drasi-project/drasi-server/releases" target="_blank" rel="noopener noreferrer">Drasi Server releases page</a>.
 
 ```text
-drasi-server 0.2.0
+drasi-server 0.2.1
 rustc: rustc 1.88.0 (6b00bc388 2025-06-23)
-plugin-sdk: 0.8.4
+plugin-sdk: 0.9.1
 ```
 
 ## Step 4: Build the SSE CLI
@@ -119,7 +119,7 @@ Verify the `drasi-sse-cli` binary works:
 ./bin/drasi-sse-cli --version
 ```
 
-You should see output showing the version number, for example:
+You should see output showing the version number. The exact version depends on which release you have installed, so the number below is only an example. The latest release is always available from the <a href="https://github.com/drasi-project/drasi-server/releases" target="_blank" rel="noopener noreferrer">Drasi Server releases page</a>.
 
 ```text
 drasi-sse-cli 0.1.0

--- a/docs/content/drasi-server/getting-started/dev-container/_index.md
+++ b/docs/content/drasi-server/getting-started/dev-container/_index.md
@@ -63,10 +63,12 @@ Verify that Drasi Server is accessible by running the following command in the t
 ./bin/drasi-server --version
 ```
 
-You should see output showing the version number, for example:
+You should see output showing the version number. The exact version depends on which release of Drasi Server you have installed, so the number below is only an example. The latest release is always available from the <a href="https://github.com/drasi-project/drasi-server/releases" target="_blank" rel="noopener noreferrer">Drasi Server releases page</a>.
 
 ```text
-drasi-server 0.2.0
+drasi-server 0.2.1
+rustc: rustc 1.88.0 (6b00bc388 2025-06-23)
+plugin-sdk: 0.9.1
 ```
 
 If you see a "file not found" error, the build may not have completed. Check the terminal output for errors and try rebuilding the container.

--- a/docs/content/drasi-server/getting-started/download-binary/_index.md
+++ b/docs/content/drasi-server/getting-started/download-binary/_index.md
@@ -61,37 +61,26 @@ To download the correct binaries for your platform run the following command:
 {{< /tab >}}
 {{< /tabpane >}}
 
-## Step 4: Verify the Binaries
-
-Before continuing, confirm that both binaries downloaded correctly and run on your platform.
-
-First, check `drasi-server`:
-
-```bash
-./bin/drasi-server --version
-```
-
-You should see output showing the version number. The exact version depends on which release of Drasi Server you have installed, so the number below is only an example. The latest release is always available from the [Drasi Server releases page](https://github.com/drasi-project/drasi-server/releases).
+The script detects your platform, downloads the matching binaries into the `./bin/` directory, and then runs each one to verify it works. When everything succeeds you'll see output similar to this:
 
 ```text
+Detected: Darwin (arm64)
+Downloading: drasi-server-aarch64-apple-darwin
+Downloading: drasi-sse-cli-aarch64-apple-darwin
+
+Verifying installations...
 drasi-server 0.2.1
 rustc: rustc 1.88.0 (6b00bc388 2025-06-23)
 plugin-sdk: 0.9.1
-```
-
-Next, check `drasi-sse-cli`:
-
-```bash
-./bin/drasi-sse-cli --version
-```
-
-You should see output showing the version number. The exact version depends on which release you have installed, so the number below is only an example.
-
-```text
 drasi-sse-cli 0.1.0
+
+✅ Drasi Server installed to bin/drasi-server
+✅ Drasi SSE CLI installed to bin/drasi-sse-cli
 ```
 
-If both commands print version information, your binaries are working correctly and you're ready to continue. If you see a "command not found", "permission denied", or similar error, the download may not have completed — re-run the download command in [Step 3](#step-3-download-drasi-binaries), then try again.
+The script runs both binaries for you (the `Verifying installations...` section), so there's no need to test them manually. The exact version numbers depend on which release the script downloads, so the values above are only examples — the latest release is always available from the [Drasi Server releases page](https://github.com/drasi-project/drasi-server/releases).
+
+The two `✅` lines confirm both binaries were installed and ran successfully. If you don't see them, the download didn't complete — re-run the command above. If it keeps failing, check that `curl` is installed (see the [troubleshooting section](#troubleshooting) below).
 
 ## ✅ Setup Complete
 

--- a/docs/content/drasi-server/getting-started/download-binary/_index.md
+++ b/docs/content/drasi-server/getting-started/download-binary/_index.md
@@ -61,6 +61,38 @@ To download the correct binaries for your platform run the following command:
 {{< /tab >}}
 {{< /tabpane >}}
 
+## Step 4: Verify the Binaries
+
+Before continuing, confirm that both binaries downloaded correctly and run on your platform.
+
+First, check `drasi-server`:
+
+```bash
+./bin/drasi-server --version
+```
+
+You should see output showing the version number. The exact version depends on which release of Drasi Server you have installed, so the number below is only an example. The latest release is always available from the [Drasi Server releases page](https://github.com/drasi-project/drasi-server/releases).
+
+```text
+drasi-server 0.2.1
+rustc: rustc 1.88.0 (6b00bc388 2025-06-23)
+plugin-sdk: 0.9.1
+```
+
+Next, check `drasi-sse-cli`:
+
+```bash
+./bin/drasi-sse-cli --version
+```
+
+You should see output showing the version number. The exact version depends on which release you have installed, so the number below is only an example.
+
+```text
+drasi-sse-cli 0.1.0
+```
+
+If both commands print version information, your binaries are working correctly and you're ready to continue. If you see a "command not found", "permission denied", or similar error, the download may not have completed — re-run the download command in [Step 3](#step-3-download-drasi-binaries), then try again.
+
 ## ✅ Setup Complete
 
 You now have Drasi Server accessible at `./bin/drasi-server` from the repository root.

--- a/docs/content/drasi-server/getting-started/github-codespace/_index.md
+++ b/docs/content/drasi-server/getting-started/github-codespace/_index.md
@@ -55,10 +55,12 @@ Verify that Drasi Server is accessible:
 ./bin/drasi-server --version
 ```
 
-You should see output showing the version number, for example:
+You should see output showing the version number. The exact version depends on which release of Drasi Server you have installed, so the number below is only an example. The latest release is always available from the [Drasi Server releases page](https://github.com/drasi-project/drasi-server/releases).
 
 ```text
-drasi-server 0.2.0
+drasi-server 0.2.1
+rustc: rustc 1.88.0 (6b00bc388 2025-06-23)
+plugin-sdk: 0.9.1
 ```
 
 ## ✅ Setup Complete

--- a/docs/shared-content/installation/drasi-server/download-binary.md
+++ b/docs/shared-content/installation/drasi-server/download-binary.md
@@ -47,8 +47,10 @@ Verify the binary works:
 ./bin/drasi-server --version
 ```
 
-You should see output showing the version number, for example:
+You should see output showing the version number. The exact version depends on which release of Drasi Server you have installed, so the number below is only an example. The latest release is always available from the [Drasi Server releases page](https://github.com/drasi-project/drasi-server/releases).
 
 ```text
-drasi-server 0.1.0
+drasi-server 0.2.1
+rustc: rustc 1.88.0 (6b00bc388 2025-06-23)
+plugin-sdk: 0.9.1
 ```

--- a/docs/shared-content/installation/drasi-server/download-sse-cli-binary.md
+++ b/docs/shared-content/installation/drasi-server/download-sse-cli-binary.md
@@ -47,7 +47,7 @@ Verify the binary works:
 ./bin/drasi-sse-cli --version
 ```
 
-You should see output showing the version number, for example:
+You should see output showing the version number. The exact version depends on which release you have installed, so the number below is only an example. The latest release is always available from the [Drasi Server releases page](https://github.com/drasi-project/drasi-server/releases).
 
 ```text
 drasi-sse-cli 0.1.0

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,10 @@ Alternatively, you can follow the instructions below to setup and run a local Hu
 
      ```hugo server --disableFastRender```
 
+     > **Note:** If the server takes a long time to start and `http://localhost:1313/` shows no content until it finishes, you are likely running from a networked or external/mounted volume where Hugo's native file watching is slow to set up. Add the `--poll` flag to use polling instead:
+
+     ```hugo server --disableFastRender --poll 700ms```
+
 ### Browse the documentation
 
 The documentation website will be accessible on the URL **http://localhost:1313/**


### PR DESCRIPTION
…on step

Specific Drasi Server and SSE CLI version numbers in the `--version` example output required a docs refresh on every release. Replace them with indicative versions plus a note explaining the exact version depends on the installed release, and link to the Drasi Server releases page for the latest. Standardize the indicative drasi-server version to 0.2.0 (the download-binary snippet previously showed 0.1.0).

Also add a "Step 4: Verify the Binaries" step to the getting-started download-binary tutorial so users test-run both binaries before continuing, matching the verification step already present on the other setup paths.