### PR TITLE
Update server installation docs

### DIFF
--- a/docs/content/drasi-server/how-to-guides/installation/install-with-docker/_index.md
+++ b/docs/content/drasi-server/how-to-guides/installation/install-with-docker/_index.md
@@ -133,7 +133,7 @@ docker run -d \
 Configure the state store in your configuration:
 
 ```yaml
-state_store:
+stateStore:
   kind: redb
   path: /data/state.redb
 ```
@@ -281,7 +281,7 @@ docker run -d \
 Or in the configuration file:
 
 ```yaml
-log_level: debug  # trace, debug, info, warn, error
+logLevel: debug  # trace, debug, info, warn, error
 ```
 
 ## Container Management

--- a/docs/shared-content/installation/drasi-server/build-from-source-prereqs.md
+++ b/docs/shared-content/installation/drasi-server/build-from-source-prereqs.md
@@ -3,10 +3,13 @@ Building `drasi-server` requires several native C libraries. Install the depende
 
 #### macOS
 
-Xcode Command Line Tools provide `clang` and `perl`. Install the remaining dependencies with Homebrew:
+Install Xcode Command Line Tools to get `clang` and `perl`.
+
+Then install the remaining dependencies with Homebrew:
 
 ```bash
 brew install protobuf
+brew install jq
 ```
 
 #### Debian / Ubuntu
@@ -19,75 +22,15 @@ sudo apt-get install -y libssl-dev pkg-config clang libclang-dev libjq-dev libon
 
 #### Windows
 
-Building natively on Windows requires MSYS2, LLVM, Strawberry Perl, and protoc.
-
-##### 1. Install MSYS2
-
-MSYS2 provides Unix-like build tools and C libraries needed for native dependencies (OpenSSL, RocksDB, etc.).
+Building natively on Windows requires the Visual Studio 2022 Build Tools (for the MSVC toolchain):
 
 ```powershell
-winget install MSYS2.MSYS2
+winget install --id Microsoft.VisualStudio.2022.BuildTools -e `
+    --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
 ```
 
-Then install the required packages:
+Then install the pinned Rust MSVC toolchain:
 
 ```powershell
-pacman -S --noconfirm `
-    make `
-    perl `
-    mingw-w64-ucrt-x86_64-gcc `
-    mingw-w64-ucrt-x86_64-pkg-config `
-    mingw-w64-ucrt-x86_64-clang
-```
-
-##### 2. Install LLVM
-
-```powershell
-winget install LLVM.LLVM
-```
-
-##### 3. Install Strawberry Perl
-
-> **Note:** MSYS2's `perl` must appear **before** Strawberry Perl on PATH.
-> OpenSSL's build requires Unix-like paths that only MSYS2's perl provides.
-
-```powershell
-winget install StrawberryPerl.StrawberryPerl
-```
-
-##### 4. Install Protocol Buffers Compiler
-
-```powershell
-winget install Google.Protobuf
-```
-
-If `protoc` is not on your PATH after installation:
-
-```powershell
-$env:PROTOC = "C:\path\to\protoc.exe"
-```
-
-##### 5. Switch to the GNU Toolchain
-
-This project's `rust-toolchain.toml` pins Rust 1.88.0 and defaults to the MSVC target.
-Since we link against MSYS2 libraries, we need the GNU toolchain. Setting `$env:RUSTUP_TOOLCHAIN`
-overrides `rust-toolchain.toml` (note: `rustup default` alone is **not** sufficient).
-
-```powershell
-rustup toolchain install 1.88.0-x86_64-pc-windows-gnu
-$env:RUSTUP_TOOLCHAIN = "1.88.0-x86_64-pc-windows-gnu"
-```
-
-##### 6. Set PATH
-
-MSYS2 paths must come **before** Strawberry Perl so that OpenSSL uses MSYS2's Unix-like `perl`:
-
-```powershell
-$env:PATH = "C:\msys64\ucrt64\bin;C:\msys64\usr\bin;C:\Strawberry\perl\bin;" + $env:PATH
-```
-
-##### 7. Set Tool Paths
-
-```powershell
-$env:LIBCLANG_PATH = "C:\Program Files\LLVM\bin"
+rustup toolchain install 1.88.0-x86_64-pc-windows-msvc
 ```

--- a/docs/shared-content/installation/drasi-server/download-binary.md
+++ b/docs/shared-content/installation/drasi-server/download-binary.md
@@ -35,7 +35,7 @@ chmod +x bin/drasi-server
 {{< /tab >}}
 {{< tab header="Windows (x64)" lang="powershell" >}}
 New-Item -ItemType Directory -Force -Path bin
-Invoke-WebRequest -Uri "https://github.com/drasi-project/drasi-server/releases/latest/download/drasi-server-x86_64-windows.exe" -OutFile "bin\drasi-server.exe"
+Invoke-WebRequest -Uri "https://github.com/drasi-project/drasi-server/releases/latest/download/drasi-server-x86_64-windows-msvc.exe" -OutFile "bin\drasi-server.exe"
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/docs/shared-content/installation/drasi-server/download-sse-cli-binary.md
+++ b/docs/shared-content/installation/drasi-server/download-sse-cli-binary.md
@@ -35,7 +35,7 @@ chmod +x bin/drasi-sse-cli
 {{< /tab >}}
 {{< tab header="Windows (x64)" lang="powershell" >}}
 New-Item -ItemType Directory -Force -Path bin
-Invoke-WebRequest -Uri "https://github.com/drasi-project/drasi-server/releases/latest/download/drasi-sse-cli-x86_64-windows.exe" -OutFile "bin\drasi-server.exe"
+Invoke-WebRequest -Uri "https://github.com/drasi-project/drasi-server/releases/latest/download/drasi-sse-cli-x86_64-windows.exe" -OutFile "bin\drasi-sse-cli.exe"
 {{< /tab >}}
 {{< /tabpane >}}
 


### PR DESCRIPTION
# Description

When we previously renamed the windows binaries in the release workflow for drasi-server, we only updated the installation scripts in the getting started tutorial, but forgot to update the general installation docs for drasi-server.


This PR corrects outdated and inconsistent details across the Drasi Server installation docs. It updates the binary download instructions to match the latest release (Windows server binary renamed to drasi-server-x86_64-windows-msvc.exe, and fixes the SSE CLI Windows output filename), aligns the "build from source" native-dependency prerequisites with the getting-started guide (MSVC toolchain on Windows, jq on macOS), and fixes invalid config field names in the Docker guide (state_store→stateStore, log_level→logLevel)


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #250 
