### PR TITLE
Updated Drasi Server "Build from Source" installation guide and added CI verification

### DIFF
--- a/.github/scripts/extract-doc-commands.js
+++ b/.github/scripts/extract-doc-commands.js
@@ -2,15 +2,25 @@
 /*
  * Extracts documented shell commands straight from the installation guide so
  * CI runs exactly what the docs tell users to run (no hardcoded copies that can
- * drift). Commands are identified by the stable id attached to their fenced
- * code block in Markdown, e.g.:
+ * drift). Commands are identified either by the stable id attached to their
+ * fenced code block in Markdown, e.g.:
  *
  *     ```bash {#build-drasi-server}
  *     cargo install --path . --root . --locked
  *     ```
  *
+ * ...or, for commands presented inside Docsy tab shortcodes (which have no code
+ * fence to hang an id on), by the tab's `header`, e.g.:
+ *
+ *     {{< tab header="Linux (x64)" lang="bash" >}}
+ *     mkdir -p bin
+ *     curl -fsSL .../drasi-server-x86_64-linux-gnu -o bin/drasi-server
+ *     {{< /tab >}}
+ *
  * Usage:
- *   node .github/scripts/extract-doc-commands.js <linux|macos|windows> <prereqs|build>
+ *   node .github/scripts/extract-doc-commands.js <target> <group>
+ *     build-from-source: <linux|macos|windows> <prereqs|build>
+ *     download-binary:   <download-*> <download|verify>
  *
  * Prints the concatenated command text (in documented order) to stdout.
  */
@@ -24,31 +34,52 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const PREREQS = 'docs/shared-content/installation/drasi-server/build-from-source-prereqs.md';
 const BUILD = 'docs/content/drasi-server/how-to-guides/installation/build-from-source/_index.md';
 const SSE = 'docs/content/drasi-server/how-to-guides/installation/install-sse-cli/_index.md';
+const DOWNLOAD = 'docs/shared-content/installation/drasi-server/download-binary.md';
 
 // The build/verify sequence is identical across platforms; only the native
-// dependency step differs. Each entry is [file, snippetId] in execution order.
+// dependency step differs. Each entry is { file, id } (fenced code block) or
+// { file, tab } (Docsy tab shortcode), in execution order.
 const BUILD_SEQUENCE = [
-  [BUILD, 'clone-drasi-server'],
-  [BUILD, 'build-drasi-server'],
-  [BUILD, 'verify-drasi-server'],
-  [SSE, 'build-sse-cli'],
-  [SSE, 'verify-sse-cli'],
+  { file: BUILD, id: 'clone-drasi-server' },
+  { file: BUILD, id: 'build-drasi-server' },
+  { file: BUILD, id: 'verify-drasi-server' },
+  { file: SSE, id: 'build-sse-cli' },
+  { file: SSE, id: 'verify-sse-cli' },
 ];
 
 const MANIFEST = {
   linux: {
-    prereqs: [[PREREQS, 'linux-native-deps'], [PREREQS, 'linux-jq-lib-dir']],
+    prereqs: [{ file: PREREQS, id: 'linux-native-deps' }, { file: PREREQS, id: 'linux-jq-lib-dir' }],
     build: BUILD_SEQUENCE,
   },
   macos: {
-    prereqs: [[PREREQS, 'macos-native-deps'], [PREREQS, 'macos-jq-lib-dir']],
+    prereqs: [{ file: PREREQS, id: 'macos-native-deps' }, { file: PREREQS, id: 'macos-jq-lib-dir' }],
     build: BUILD_SEQUENCE,
   },
   windows: {
-    prereqs: [[PREREQS, 'windows-native-deps']],
+    prereqs: [{ file: PREREQS, id: 'windows-native-deps' }],
     build: BUILD_SEQUENCE,
   },
 };
+
+// The Download Binary guide presents one command block per platform/arch inside
+// Docsy tab shortcodes. Each variant maps to its tab header; the verify step is
+// the same fenced block for every variant.
+const DOWNLOAD_TABS = {
+  'download-macos-apple-silicon': 'macOS (Apple Silicon)',
+  'download-macos-intel': 'macOS (Intel)',
+  'download-linux-x64': 'Linux (x64)',
+  'download-linux-arm64': 'Linux (ARM64)',
+  'download-linux-musl-x64': 'Linux musl (x64)',
+  'download-linux-musl-arm64': 'Linux musl (ARM64)',
+  'download-windows-x64': 'Windows (x64)',
+};
+for (const [target, header] of Object.entries(DOWNLOAD_TABS)) {
+  MANIFEST[target] = {
+    download: [{ file: DOWNLOAD, tab: header }],
+    verify: [{ file: DOWNLOAD, id: 'verify-download' }],
+  };
+}
 
 /**
  * Return the body of the fenced code block whose opening fence carries `{#id}`.
@@ -76,17 +107,51 @@ function extractSnippet(file, id) {
   throw new Error(`Unterminated snippet #${id} in ${file}`);
 }
 
+/**
+ * Return the body of a Docsy tab shortcode identified by its `header`.
+ * @param {string} file Repo-relative path to a Markdown file.
+ * @param {string} header The tab's `header="..."` value.
+ */
+function extractTab(file, header) {
+  const abs = path.join(REPO_ROOT, file);
+  const lines = fs.readFileSync(abs, 'utf8').split(/\r?\n/);
+  const escaped = header.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+  const openTab = new RegExp('{{[<%]\\s*tab\\b[^}]*header="' + escaped + '"');
+  const closeTab = /{{[<%]\s*\/tab\s*[%>]}}/;
+
+  let i = lines.findIndex((line) => openTab.test(line));
+  if (i === -1) {
+    throw new Error(`Tab "${header}" not found in ${file}`);
+  }
+
+  const body = [];
+  for (i += 1; i < lines.length; i++) {
+    if (closeTab.test(lines[i])) {
+      return body.join('\n');
+    }
+    body.push(lines[i]);
+  }
+  throw new Error(`Unterminated tab "${header}" in ${file}`);
+}
+
+/** Dispatch an entry to the right extractor based on whether it names an id or a tab. */
+function extractEntry(entry) {
+  return entry.tab ? extractTab(entry.file, entry.tab) : extractSnippet(entry.file, entry.id);
+}
+
 function main() {
-  const [platform, group] = process.argv.slice(2);
-  const groups = MANIFEST[platform];
+  const [target, group] = process.argv.slice(2);
+  const groups = MANIFEST[target];
   if (!groups || !groups[group]) {
     process.stderr.write(
-      'Usage: node .github/scripts/extract-doc-commands.js <linux|macos|windows> <prereqs|build>\n'
+      'Usage: node .github/scripts/extract-doc-commands.js <target> <group>\n' +
+      '  build-from-source: <linux|macos|windows> <prereqs|build>\n' +
+      '  download-binary:   <download-*> <download|verify>\n'
     );
     process.exit(2);
   }
 
-  const script = groups[group].map(([file, id]) => extractSnippet(file, id)).join('\n');
+  const script = groups[group].map(extractEntry).join('\n');
   process.stdout.write(script + '\n');
 }
 

--- a/.github/scripts/extract-doc-commands.js
+++ b/.github/scripts/extract-doc-commands.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/*
+ * Extracts documented shell commands straight from the installation guide so
+ * CI runs exactly what the docs tell users to run (no hardcoded copies that can
+ * drift). Commands are identified by the stable id attached to their fenced
+ * code block in Markdown, e.g.:
+ *
+ *     ```bash {#build-drasi-server}
+ *     cargo install --path . --root . --locked
+ *     ```
+ *
+ * Usage:
+ *   node .github/scripts/extract-doc-commands.js <linux|macos> <prereqs|build>
+ *
+ * Prints the concatenated command text (in documented order) to stdout.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+const PREREQS = 'docs/shared-content/installation/drasi-server/build-from-source-prereqs.md';
+const BUILD = 'docs/content/drasi-server/how-to-guides/installation/build-from-source/_index.md';
+const SSE = 'docs/content/drasi-server/how-to-guides/installation/install-sse-cli/_index.md';
+
+// The build/verify sequence is identical across platforms; only the native
+// dependency step differs. Each entry is [file, snippetId] in execution order.
+const BUILD_SEQUENCE = [
+  [BUILD, 'clone-drasi-server'],
+  [BUILD, 'build-drasi-server'],
+  [BUILD, 'verify-drasi-server'],
+  [SSE, 'build-sse-cli'],
+  [SSE, 'verify-sse-cli'],
+];
+
+const MANIFEST = {
+  linux: {
+    prereqs: [[PREREQS, 'linux-native-deps']],
+    build: BUILD_SEQUENCE,
+  },
+  macos: {
+    prereqs: [[PREREQS, 'macos-native-deps'], [PREREQS, 'macos-jq-lib-dir']],
+    build: BUILD_SEQUENCE,
+  },
+};
+
+/**
+ * Return the body of the fenced code block whose opening fence carries `{#id}`.
+ * @param {string} file Repo-relative path to a Markdown file.
+ * @param {string} id Snippet id declared as `{#id}` on the code fence.
+ */
+function extractSnippet(file, id) {
+  const abs = path.join(REPO_ROOT, file);
+  const lines = fs.readFileSync(abs, 'utf8').split(/\r?\n/);
+  const escaped = id.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+  const openFence = new RegExp('^```.*\\{#' + escaped + '\\}');
+
+  let i = lines.findIndex((line) => openFence.test(line));
+  if (i === -1) {
+    throw new Error(`Snippet #${id} not found in ${file}`);
+  }
+
+  const body = [];
+  for (i += 1; i < lines.length; i++) {
+    if (/^```\s*$/.test(lines[i])) {
+      return body.join('\n');
+    }
+    body.push(lines[i]);
+  }
+  throw new Error(`Unterminated snippet #${id} in ${file}`);
+}
+
+function main() {
+  const [platform, group] = process.argv.slice(2);
+  const groups = MANIFEST[platform];
+  if (!groups || !groups[group]) {
+    process.stderr.write(
+      'Usage: node .github/scripts/extract-doc-commands.js <linux|macos> <prereqs|build>\n'
+    );
+    process.exit(2);
+  }
+
+  const script = groups[group].map(([file, id]) => extractSnippet(file, id)).join('\n');
+  process.stdout.write(script + '\n');
+}
+
+main();

--- a/.github/scripts/extract-doc-commands.js
+++ b/.github/scripts/extract-doc-commands.js
@@ -37,7 +37,7 @@ const BUILD_SEQUENCE = [
 
 const MANIFEST = {
   linux: {
-    prereqs: [[PREREQS, 'linux-native-deps']],
+    prereqs: [[PREREQS, 'linux-native-deps'], [PREREQS, 'linux-jq-lib-dir']],
     build: BUILD_SEQUENCE,
   },
   macos: {

--- a/.github/scripts/extract-doc-commands.js
+++ b/.github/scripts/extract-doc-commands.js
@@ -10,7 +10,7 @@
  *     ```
  *
  * Usage:
- *   node .github/scripts/extract-doc-commands.js <linux|macos> <prereqs|build>
+ *   node .github/scripts/extract-doc-commands.js <linux|macos|windows> <prereqs|build>
  *
  * Prints the concatenated command text (in documented order) to stdout.
  */
@@ -42,6 +42,10 @@ const MANIFEST = {
   },
   macos: {
     prereqs: [[PREREQS, 'macos-native-deps'], [PREREQS, 'macos-jq-lib-dir']],
+    build: BUILD_SEQUENCE,
+  },
+  windows: {
+    prereqs: [[PREREQS, 'windows-native-deps']],
     build: BUILD_SEQUENCE,
   },
 };
@@ -77,7 +81,7 @@ function main() {
   const groups = MANIFEST[platform];
   if (!groups || !groups[group]) {
     process.stderr.write(
-      'Usage: node .github/scripts/extract-doc-commands.js <linux|macos> <prereqs|build>\n'
+      'Usage: node .github/scripts/extract-doc-commands.js <linux|macos|windows> <prereqs|build>\n'
     );
     process.exit(2);
   }

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout docs
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Spellcheck
       uses: rojopolis/spellcheck-github-actions@0.51.0
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       HUGO_VERSION: 0.128.0
     steps:
       - name: Checkout docs repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
 

--- a/.github/workflows/verify-build-from-source.yml
+++ b/.github/workflows/verify-build-from-source.yml
@@ -61,7 +61,15 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout docs repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+
+      # The GitHub macOS runners ship an untrusted `aws/tap`; any `brew` command
+      # (such as the documented `brew install`) then prints a tap-trust warning.
+      # We don't use that tap, so remove it to keep the build log clean.
+      - name: Remove untrusted preinstalled Homebrew tap (macOS)
+        if: matrix.platform == 'macos'
+        shell: bash
+        run: brew untap aws/tap || true
 
       - name: Follow the Build from Source guide
         if: matrix.platform != 'windows'

--- a/.github/workflows/verify-build-from-source.yml
+++ b/.github/workflows/verify-build-from-source.yml
@@ -82,7 +82,7 @@ jobs:
             echo "cargo --version"
           } >> steps.sh
 
-          # 3. Clone, build, verify, and build the SSE CLI (extracted from the docs).
+          # 3. Clone, build & verify drasi-server, then build & verify the SSE CLI (extracted from the docs).
           node .github/scripts/extract-doc-commands.js "${{ matrix.platform }}" build >> steps.sh
 
           echo "----- assembled script -----"
@@ -116,7 +116,7 @@ jobs:
           Add-Content steps.ps1 "rustc --version"
           Add-Content steps.ps1 "cargo --version"
 
-          # 3. Clone, build, verify, and build the SSE CLI (extracted from the docs).
+          # 3. Clone, build & verify drasi-server, then build & verify the SSE CLI (extracted from the docs).
           node .github/scripts/extract-doc-commands.js "${{ matrix.platform }}" build | Add-Content steps.ps1
 
           Write-Output "----- assembled script -----"

--- a/.github/workflows/verify-build-from-source.yml
+++ b/.github/workflows/verify-build-from-source.yml
@@ -59,9 +59,12 @@ jobs:
           - os: macos-latest
             platform: macos
             label: macOS (Apple Silicon)
-          - os: macos-13
+          - os: macos-26-intel
             platform: macos
             label: macOS (Intel)
+          - os: windows-latest
+            platform: windows
+            label: Windows
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -69,6 +72,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Follow the Build from Source guide
+        if: matrix.platform != 'windows'
         shell: bash
         run: |
           set -euo pipefail
@@ -98,3 +102,37 @@ jobs:
           # (e.g. JQ_LIB_DIR) and directory changes (cd drasi-server) persist,
           # exactly as a user working in one terminal would experience.
           bash -euo pipefail steps.sh
+
+      - name: Follow the Build from Source guide (Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          Write-Output "::group::Assemble script from documented commands"
+
+          # Fail fast, including on any non-zero exit from a native command.
+          Set-Content steps.ps1 "`$ErrorActionPreference = 'Stop'"
+          Add-Content steps.ps1 "`$PSNativeCommandUseErrorActionPreference = `$true"
+
+          # 1. Native build dependencies (extracted verbatim from the docs).
+          node .github/scripts/extract-doc-commands.js "${{ matrix.platform }}" prereqs | Add-Content steps.ps1
+
+          # 2. Rust toolchain. On Windows the default host triple is
+          #    x86_64-pc-windows-msvc, so installing ${{ env.RUST_VERSION }}
+          #    matches the pinned MSVC toolchain the guide requires.
+          Add-Content steps.ps1 "rustup toolchain install $env:RUST_VERSION"
+          Add-Content steps.ps1 "rustup default $env:RUST_VERSION"
+          Add-Content steps.ps1 "rustc --version"
+          Add-Content steps.ps1 "cargo --version"
+
+          # 3. Clone, build, verify, and build the SSE CLI (extracted from the docs).
+          node .github/scripts/extract-doc-commands.js "${{ matrix.platform }}" build | Add-Content steps.ps1
+
+          Write-Output "----- assembled script -----"
+          Get-Content steps.ps1
+          Write-Output "----------------------------"
+          Write-Output "::endgroup::"
+
+          # Run everything in a single shell so documented directory changes
+          # (cd drasi-server) persist, exactly as a user working in one terminal
+          # would experience.
+          pwsh -NoProfile -File steps.ps1

--- a/.github/workflows/verify-build-from-source.yml
+++ b/.github/workflows/verify-build-from-source.yml
@@ -19,19 +19,11 @@ name: Verify Build from Source
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'docs/content/drasi-server/how-to-guides/installation/build-from-source/**'
-      - 'docs/content/drasi-server/how-to-guides/installation/install-sse-cli/**'
-      - 'docs/shared-content/installation/drasi-server/build-from-source-prereqs.md'
-      - 'docs/shared-content/installation/drasi-server/download-sse-cli-binary.md'
-      - '.github/scripts/extract-doc-commands.js'
-      - '.github/workflows/verify-build-from-source.yml'
+    branches:
+      - main
   schedule:
     # Weekly, to catch upstream drasi-server changes that break the docs.
     - cron: '0 6 * * 1'
-  push:
-    branches:
-      - drasi-server-installation
 
 # The guide requires Rust installed via rustup; it defers the install itself to
 # the rustup site, so the version below is the only value not read from a doc
@@ -136,3 +128,59 @@ jobs:
           # (cd drasi-server) persist, exactly as a user working in one terminal
           # would experience.
           pwsh -NoProfile -File steps.ps1
+
+  # Open a tracking issue when the *scheduled* run fails, so a broken
+  # build-from-source guide (docs drift or an upstream drasi-server change)
+  # doesn't go unnoticed. Deliberately scoped to schedule only: pull_request
+  # and workflow_dispatch failures are already visible to whoever triggered
+  # them, so they don't need an issue.
+  report-failure:
+    name: Open issue on scheduled failure
+    needs: build-from-source
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create or update tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'build-from-source-failure';
+            const title = 'Scheduled "Verify Build from Source" run failed';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              'The scheduled **Verify Build from Source** workflow failed.',
+              '',
+              `- Run: ${runUrl}`,
+              `- Commit: \`${context.sha}\``,
+              '',
+              'The documented build-from-source steps may be broken (docs drift or an upstream `drasi-server` change). Check the failing matrix job(s) in the run above.',
+            ].join('\n');
+
+            // Avoid piling up duplicates on repeated weekly failures: if an open
+            // tracking issue already exists, add a comment instead of a new issue.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            });
+
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [label],
+              });
+            }
+

--- a/.github/workflows/verify-build-from-source.yml
+++ b/.github/workflows/verify-build-from-source.yml
@@ -154,7 +154,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const label = 'build-from-source-failure';
+            const label = 'bug';
             const title = 'Scheduled "Verify Build from Source" run failed';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = [
@@ -166,20 +166,23 @@ jobs:
               'The documented build-from-source steps may be broken (docs drift or an upstream `drasi-server` change). Check the failing matrix job(s) in the run above.',
             ].join('\n');
 
-            // Avoid piling up duplicates on repeated weekly failures: if an open
-            // tracking issue already exists, add a comment instead of a new issue.
+            // The `bug` label is shared with other issues, so de-duplicate on the
+            // exact title: comment on our own open tracking issue if one exists,
+            // otherwise open a new one.
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               labels: label,
+              per_page: 100,
             });
+            const tracking = existing.data.find((issue) => issue.title === title);
 
-            if (existing.data.length > 0) {
+            if (tracking) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: existing.data[0].number,
+                issue_number: tracking.number,
                 body,
               });
             } else {

--- a/.github/workflows/verify-build-from-source.yml
+++ b/.github/workflows/verify-build-from-source.yml
@@ -1,0 +1,100 @@
+name: Verify Build from Source
+
+# Validates that the "Build from Source" installation guide works on a clean
+# machine, across multiple OS/arch environments.
+#
+# This is a deterministic test (no AI agent required), but it does NOT hardcode
+# the documented commands: each step is extracted at runtime from the Markdown
+# docs by the stable id on its code fence (see
+# .github/scripts/extract-doc-commands.js). If the docs change, the workflow
+# runs the new commands automatically, so the two cannot silently drift apart.
+#
+# Docs under test:
+#   - docs/content/drasi-server/how-to-guides/installation/build-from-source/
+#   - docs/content/drasi-server/how-to-guides/installation/install-sse-cli/
+#   - docs/shared-content/installation/drasi-server/build-from-source-prereqs.md
+#
+# Related issue: https://github.com/drasi-project/docs/issues/259
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'docs/content/drasi-server/how-to-guides/installation/build-from-source/**'
+      - 'docs/content/drasi-server/how-to-guides/installation/install-sse-cli/**'
+      - 'docs/shared-content/installation/drasi-server/build-from-source-prereqs.md'
+      - 'docs/shared-content/installation/drasi-server/download-sse-cli-binary.md'
+      - '.github/scripts/extract-doc-commands.js'
+      - '.github/workflows/verify-build-from-source.yml'
+  schedule:
+    # Weekly, to catch upstream drasi-server changes that break the docs.
+    - cron: '0 6 * * 1'
+  push:
+    branches:
+      - drasi-server-installation
+
+# The guide requires Rust installed via rustup; it defers the install itself to
+# the rustup site, so the version below is the only value not read from a doc
+# code block. Keep it in sync with the version stated in the installation guide.
+env:
+  RUST_VERSION: '1.95.0'
+
+concurrency:
+  group: verify-build-from-source-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-from-source:
+    name: ${{ matrix.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            label: Linux (Ubuntu)
+          - os: macos-latest
+            platform: macos
+            label: macOS (Apple Silicon)
+          - os: macos-13
+            platform: macos
+            label: macOS (Intel)
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - name: Checkout docs repo
+        uses: actions/checkout@v4
+
+      - name: Follow the Build from Source guide
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "::group::Assemble script from documented commands"
+          # 1. Native build dependencies (extracted verbatim from the docs).
+          node .github/scripts/extract-doc-commands.js "${{ matrix.platform }}" prereqs > steps.sh
+
+          # 2. Rust toolchain. The guide requires >= ${RUST_VERSION} installed via
+          #    rustup, which is preinstalled on GitHub-hosted runners.
+          {
+            echo "rustup toolchain install ${RUST_VERSION}"
+            echo "rustup default ${RUST_VERSION}"
+            echo "rustc --version"
+            echo "cargo --version"
+          } >> steps.sh
+
+          # 3. Clone, build, verify, and build the SSE CLI (extracted from the docs).
+          node .github/scripts/extract-doc-commands.js "${{ matrix.platform }}" build >> steps.sh
+
+          echo "----- assembled script -----"
+          cat -n steps.sh
+          echo "----------------------------"
+          echo "::endgroup::"
+
+          # Run everything in a single shell so documented environment variables
+          # (e.g. JQ_LIB_DIR) and directory changes (cd drasi-server) persist,
+          # exactly as a user working in one terminal would experience.
+          bash -euo pipefail steps.sh

--- a/.github/workflows/verify-download-binary.yml
+++ b/.github/workflows/verify-download-binary.yml
@@ -147,7 +147,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const label = 'download-binary-failure';
+            const label = 'bug';
             const title = 'Scheduled "Verify Download Binary" run failed';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = [
@@ -159,20 +159,23 @@ jobs:
               'The documented download-binary steps may be broken (docs drift or a new `drasi-server` release with renamed/missing assets). Check the failing matrix job(s) in the run above.',
             ].join('\n');
 
-            // Avoid piling up duplicates on repeated weekly failures: if an open
-            // tracking issue already exists, add a comment instead of a new issue.
+            // The `bug` label is shared with other issues, so de-duplicate on the
+            // exact title: comment on our own open tracking issue if one exists,
+            // otherwise open a new one.
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               labels: label,
+              per_page: 100,
             });
+            const tracking = existing.data.find((issue) => issue.title === title);
 
-            if (existing.data.length > 0) {
+            if (tracking) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: existing.data[0].number,
+                issue_number: tracking.number,
                 body,
               });
             } else {

--- a/.github/workflows/verify-download-binary.yml
+++ b/.github/workflows/verify-download-binary.yml
@@ -1,0 +1,186 @@
+name: Verify Download Binary
+
+# Validates that the "Download Binary" installation guide works on a clean
+# machine, across every documented platform/arch variant.
+#
+# Like the build-from-source check, this does NOT hardcode the documented
+# commands: each variant's commands are extracted at runtime from the Markdown
+# docs (see .github/scripts/extract-doc-commands.js) — by the tab's `header` for
+# the per-platform download blocks, and by code-fence id for the shared verify
+# step. If the docs change, the workflow runs the new commands automatically, so
+# the two cannot silently drift apart.
+#
+# Docs under test:
+#   - docs/shared-content/installation/drasi-server/download-binary.md
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Weekly, to catch new drasi-server releases whose assets break the docs.
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: verify-download-binary-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  download-binary:
+    name: ${{ matrix.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            variant: download-macos-apple-silicon
+            method: bash
+            label: macOS (Apple Silicon)
+          - os: macos-26-intel
+            variant: download-macos-intel
+            method: bash
+            label: macOS (Intel)
+          - os: ubuntu-latest
+            variant: download-linux-x64
+            method: bash
+            label: Linux x64 (glibc)
+          - os: ubuntu-24.04-arm
+            variant: download-linux-arm64
+            method: bash
+            label: Linux ARM64 (glibc)
+          - os: ubuntu-latest
+            variant: download-linux-musl-x64
+            method: musl
+            label: Linux x64 (musl / Alpine)
+          - os: ubuntu-24.04-arm
+            variant: download-linux-musl-arm64
+            method: musl
+            label: Linux ARM64 (musl / Alpine)
+          - os: windows-latest
+            variant: download-windows-x64
+            method: pwsh
+            label: Windows x64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - name: Checkout docs repo
+        uses: actions/checkout@v4
+
+      - name: Follow the Download Binary guide
+        if: matrix.method == 'bash'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "::group::Assemble script from documented commands"
+          # Documented download command for this platform (extracted verbatim),
+          # followed by the shared verify step.
+          node .github/scripts/extract-doc-commands.js "${{ matrix.variant }}" download > steps.sh
+          node .github/scripts/extract-doc-commands.js "${{ matrix.variant }}" verify >> steps.sh
+
+          echo "----- assembled script -----"
+          cat -n steps.sh
+          echo "----------------------------"
+          echo "::endgroup::"
+
+          bash -euo pipefail steps.sh
+
+      - name: Follow the Download Binary guide (musl / Alpine)
+        if: matrix.method == 'musl'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "::group::Assemble script from documented commands"
+          node .github/scripts/extract-doc-commands.js "${{ matrix.variant }}" download > steps.sh
+          node .github/scripts/extract-doc-commands.js "${{ matrix.variant }}" verify >> steps.sh
+
+          echo "----- assembled script -----"
+          cat -n steps.sh
+          echo "----------------------------"
+          echo "::endgroup::"
+
+          # The musl variant targets Alpine, so run the documented commands in a
+          # clean Alpine container. Node stays on the host (Alpine has none); only
+          # the documented commands run inside the container, against the checked
+          # out workspace mounted at /work.
+          docker run --rm -v "$PWD:/work" -w /work alpine:latest sh -euc "$(cat steps.sh)"
+
+      - name: Follow the Download Binary guide (Windows)
+        if: matrix.method == 'pwsh'
+        shell: pwsh
+        run: |
+          Write-Output "::group::Assemble script from documented commands"
+
+          # Fail fast, including on any non-zero exit from a native command.
+          Set-Content steps.ps1 "`$ErrorActionPreference = 'Stop'"
+          Add-Content steps.ps1 "`$PSNativeCommandUseErrorActionPreference = `$true"
+
+          node .github/scripts/extract-doc-commands.js "${{ matrix.variant }}" download | Add-Content steps.ps1
+          node .github/scripts/extract-doc-commands.js "${{ matrix.variant }}" verify | Add-Content steps.ps1
+
+          Write-Output "----- assembled script -----"
+          Get-Content steps.ps1
+          Write-Output "----------------------------"
+          Write-Output "::endgroup::"
+
+          pwsh -NoProfile -File steps.ps1
+
+  # Open a tracking issue when the *scheduled* run fails, so a broken
+  # download-binary guide (docs drift or a new drasi-server release with
+  # renamed/missing assets) doesn't go unnoticed. Deliberately scoped to
+  # schedule only: pull_request and workflow_dispatch failures are already
+  # visible to whoever triggered them, so they don't need an issue.
+  report-failure:
+    name: Open issue on scheduled failure
+    needs: download-binary
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create or update tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'download-binary-failure';
+            const title = 'Scheduled "Verify Download Binary" run failed';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              'The scheduled **Verify Download Binary** workflow failed.',
+              '',
+              `- Run: ${runUrl}`,
+              `- Commit: \`${context.sha}\``,
+              '',
+              'The documented download-binary steps may be broken (docs drift or a new `drasi-server` release with renamed/missing assets). Check the failing matrix job(s) in the run above.',
+            ].join('\n');
+
+            // Avoid piling up duplicates on repeated weekly failures: if an open
+            // tracking issue already exists, add a comment instead of a new issue.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            });
+
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [label],
+              });
+            }

--- a/.github/workflows/verify-download-binary.yml
+++ b/.github/workflows/verify-download-binary.yml
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout docs repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Follow the Download Binary guide
         if: matrix.method == 'bash'

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -28,7 +28,7 @@ jobs:
       HUGO_VERSION: 0.164.0
     steps:
       - name: Checkout docs repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           lfs: true

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -25,7 +25,7 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.155.3
+      HUGO_VERSION: 0.164.0
     steps:
       - name: Checkout docs repo
         uses: actions/checkout@v4

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -12,10 +12,10 @@ defaultContentLanguageInSubdir = false
 
 [languages]
   [languages.en]
-    languageName = "English"
+    label = "English"
     weight = 1
 #  [languages.es]
-#    languageName = "Español"
+#    label = "Español"
 #    contentDir = "content/es"
 #    weight = 2
 
@@ -78,6 +78,23 @@ defaultContentLanguageInSubdir = false
       # setting; the viewer must be excluded so Hugo doesn't treat its
       # index.html as page content.
       files = ['! /README.md', '! viewer/**']
+    [[module.imports.mounts]]
+      source = "tutorials/building-comfort"
+      target = "content/drasi-server/tutorials/building-comfort"
+      # Exclude the tutorial README so Hugo doesn't render it as a page.
+      files = ['! /README.md']
+    [[module.imports.mounts]]
+      source = "tutorials/high-risk-containers"
+      target = "content/drasi-server/tutorials/high-risk-containers"
+      # Exclude the tutorial README so Hugo doesn't render it as a page.
+      files = ['! /README.md']
+    [[module.imports.mounts]]
+      source = "tutorials/curbside-pickup"
+      target = "content/drasi-server/tutorials/curbside-pickup"
+      # Exclude the tutorial README and the standalone web UI app (served
+      # locally during the tutorial); its index.html must be excluded so Hugo
+      # doesn't treat it as page content.
+      files = ['! /README.md', '! webui/**']
 
 [params.search.algolia]
 appId = "Q8GYM4KCMH"

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -73,7 +73,11 @@ defaultContentLanguageInSubdir = false
     [[module.imports.mounts]]
       source = "tutorials/getting-started"
       target = "content/drasi-server/tutorials/getting-started"
-      excludeFiles = "/README.md"
+      # Exclude the tutorial README and the standalone HTML viewer app (served
+      # locally during the tutorial, not a docs page). Uses the current 'files'
+      # setting; the viewer must be excluded so Hugo doesn't treat its
+      # index.html as page content.
+      files = ['! /README.md', '! viewer/**']
 
 [params.search.algolia]
 appId = "Q8GYM4KCMH"

--- a/docs/content/drasi-server/how-to-guides/installation/_index.md
+++ b/docs/content/drasi-server/how-to-guides/installation/_index.md
@@ -37,4 +37,13 @@ description: "Deploy Drasi Server with Docker, or build from source"
       </div>
     </div>
   </a>
+  <a href="install-sse-cli/">
+    <div class="unified-card unified-card--howto">
+      <div class="unified-card-icon"><i class="fas fa-satellite-dish"></i></div>
+      <div class="unified-card-content">
+        <h3 class="unified-card-title">SSE CLI</h3>
+        <p class="unified-card-summary">Install the drasi-sse-cli companion tool for observing Server-Sent Events.</p>
+      </div>
+    </div>
+  </a>
 </div>

--- a/docs/content/drasi-server/how-to-guides/installation/build-from-source/_index.md
+++ b/docs/content/drasi-server/how-to-guides/installation/build-from-source/_index.md
@@ -21,7 +21,7 @@ Building {{< term "Drasi Server" >}} from source gives you full control over the
 
 ## Prerequisites
 
-- [Rust](https://www.rust-lang.org/tools/install) 1.88 or later
+- [Rust](https://www.rust-lang.org/tools/install) 1.95 or later
 - Git
 - C compiler (for native dependencies)
 
@@ -36,13 +36,15 @@ rustc --version
 cargo --version
 ```
 
+Drasi Server requires **Rust 1.95 or later**, and building with an older toolchain will fail. Confirm `rustc --version` reports at least `1.95.0`; if it is older, update with `rustup update`.
+
 ### Native Dependencies
 
 {{< read file="/shared-content/installation/drasi-server/build-from-source-prereqs.md" >}}
 
 ## Clone the Drasi Server Repository
 
-```bash
+```bash {#clone-drasi-server}
 git clone https://github.com/drasi-project/drasi-server.git
 cd drasi-server
 ```
@@ -51,7 +53,7 @@ cd drasi-server
 
 Build Drasi Server and install the compiled binary into a local `./bin` directory:
 
-```bash
+```bash {#build-drasi-server}
 cargo install --path . --root . --locked
 ```
 
@@ -59,7 +61,7 @@ The first build downloads and compiles all dependencies, so it can take several 
 
 ### Verify the Build
 
-```bash
+```bash {#verify-drasi-server}
 ./bin/drasi-server --version
 ```
 
@@ -67,7 +69,7 @@ You should see output showing the version number, for example:
 
 ```text
 drasi-server 0.2.1
-rustc: rustc 1.88.0 (6b00bc388 2025-06-23)
+rustc: rustc 1.95.0
 plugin-sdk: 0.9.1
 ```
 

--- a/docs/content/drasi-server/how-to-guides/installation/build-from-source/_index.md
+++ b/docs/content/drasi-server/how-to-guides/installation/build-from-source/_index.md
@@ -8,6 +8,8 @@ related:
   howto:
     - title: "Docker Installation"
       url: "/drasi-server/how-to-guides/installation/install-with-docker/"
+    - title: "Install the SSE CLI"
+      url: "/drasi-server/how-to-guides/installation/install-sse-cli/"
     - title: "Configure Drasi Server"
       url: "/drasi-server/how-to-guides/configuration/configure-drasi-server/"
   reference:
@@ -45,27 +47,40 @@ git clone https://github.com/drasi-project/drasi-server.git
 cd drasi-server
 ```
 
-## Build Options
+## Build and Install Drasi Server
 
-### Debug Build
-
-For development and debugging (faster compile, slower runtime):
+Build Drasi Server and install the compiled binary into a local `./bin` directory:
 
 ```bash
-cargo build
+cargo install --path . --root . --locked
 ```
 
-The binary will be at `target/debug/drasi-server`.
+The first build downloads and compiles all dependencies, so it can take several minutes. Subsequent builds are much faster thanks to Cargo's build cache. The `--root .` flag tells Cargo to place the compiled `drasi-server` binary in the `./bin` directory.
 
-### Release Build
-
-For production use (optimized, faster runtime):
+### Verify the Build
 
 ```bash
-cargo build --release
+./bin/drasi-server --version
 ```
 
-The binary will be at `target/release/drasi-server`.
+You should see output showing the version number, for example:
+
+```text
+drasi-server 0.2.1
+rustc: rustc 1.88.0 (6b00bc388 2025-06-23)
+plugin-sdk: 0.9.1
+```
+
+{{% alert title="Iterating on the source code?" color="info" %}}
+If you are actively modifying Drasi Server, use `cargo build` for faster, incremental debug builds and run directly with Cargo instead of reinstalling each time:
+
+```bash
+cargo build                                # debug build at target/debug/drasi-server
+cargo run -- --config config/server.yaml   # build and run in one step
+```
+
+Add `--release` for an optimized build at `target/release/drasi-server`.
+{{% /alert %}}
 
 ## Configuration
 
@@ -78,7 +93,7 @@ Create a configuration yaml file for Drasi Server. See the [Configuration Refere
 Alternatively, use the `init` command to create a starter configuration file:
 
 ```bash
-cargo run --release -- init --output config/server.yaml
+./bin/drasi-server init --output config/server.yaml
 ```
 
 ### Validate Configuration
@@ -86,36 +101,25 @@ cargo run --release -- init --output config/server.yaml
 Check your configuration file without starting the server:
 
 ```bash
-cargo run --release -- validate --config config/server.yaml
+./bin/drasi-server validate --config config/server.yaml
 
 # Show resolved environment variables
-cargo run --release -- validate --config config/server.yaml --show-resolved
+./bin/drasi-server validate --config config/server.yaml --show-resolved
 ```
 
 ### Check System Dependencies
 
 ```bash
-cargo run --release -- doctor
+./bin/drasi-server doctor
 
 # Include optional dependencies
-cargo run --release -- doctor --all
+./bin/drasi-server doctor --all
 ```
 
 ## Run Drasi Server
 
-### Using Cargo
+Run Drasi Server using the installed binary:
 
 ```bash
-# Debug mode
-cargo run -- --config config/server.yaml
-
-# Release mode
-cargo run --release -- --config config/server.yaml
-```
-
-### Using the Binary Directly
-
-```bash
-# After building
-./target/release/drasi-server --config config/server.yaml
+./bin/drasi-server --config config/server.yaml
 ```

--- a/docs/content/drasi-server/how-to-guides/installation/install-sse-cli/_index.md
+++ b/docs/content/drasi-server/how-to-guides/installation/install-sse-cli/_index.md
@@ -36,7 +36,7 @@ cd drasi-server
 
 Build and install the SSE CLI into a local `./bin` directory:
 
-```bash
+```bash {#build-sse-cli}
 cargo install --path examples/sse-cli --root . --locked
 ```
 
@@ -44,7 +44,7 @@ The `--root .` flag tells Cargo to place the compiled `drasi-sse-cli` binary in 
 
 ### Verify the Build
 
-```bash
+```bash {#verify-sse-cli}
 ./bin/drasi-sse-cli --version
 ```
 

--- a/docs/content/drasi-server/how-to-guides/installation/install-sse-cli/_index.md
+++ b/docs/content/drasi-server/how-to-guides/installation/install-sse-cli/_index.md
@@ -1,0 +1,55 @@
+---
+type: "docs"
+title: "Install the SSE CLI"
+linkTitle: "SSE CLI"
+weight: 50
+description: "Install the drasi-sse-cli companion tool"
+related:
+  howto:
+    - title: "Download Binary"
+      url: "/drasi-server/how-to-guides/installation/download-binary/"
+    - title: "Build from Source"
+      url: "/drasi-server/how-to-guides/installation/build-from-source/"
+  tutorials:
+    - title: "Getting Started"
+      url: "/drasi-server/tutorials/getting-started/"
+---
+
+The `drasi-sse-cli` is a companion command-line tool for {{< term "Drasi Server" >}} that connects to a Server-Sent Events (SSE) endpoint and prints the events it receives. It is useful for observing the output of an SSE Reaction — for example, while working through the [Getting Started tutorial](/drasi-server/tutorials/getting-started/).
+
+You can either download a pre-built binary or build it from source.
+
+## Option 1: Download a Pre-built Binary
+
+{{< read file="/shared-content/installation/drasi-server/download-sse-cli-binary.md" >}}
+
+## Option 2: Build from Source
+
+The `drasi-sse-cli` lives in the `examples/sse-cli` folder of the Drasi Server repository. Building it requires the same [prerequisites](/drasi-server/how-to-guides/installation/build-from-source/#prerequisites) as building Drasi Server itself.
+
+Clone the repository (if you haven't already):
+
+```bash
+git clone https://github.com/drasi-project/drasi-server.git
+cd drasi-server
+```
+
+Build and install the SSE CLI into a local `./bin` directory:
+
+```bash
+cargo install --path examples/sse-cli --root . --locked
+```
+
+The `--root .` flag tells Cargo to place the compiled `drasi-sse-cli` binary in the `./bin` directory.
+
+### Verify the Build
+
+```bash
+./bin/drasi-sse-cli --version
+```
+
+You should see output showing the version number, for example:
+
+```text
+drasi-sse-cli 0.1.0
+```

--- a/docs/layouts/_partials/head-css.html
+++ b/docs/layouts/_partials/head-css.html
@@ -1,0 +1,30 @@
+{{ $scssMain := "scss/main.scss" -}}
+{{ $css := resources.Get $scssMain
+      | toCSS (dict "enableSourceMap" (not hugo.IsProduction)) -}}
+
+{{/* NOTE: we only apply `postCSS` in production or for RTL languages. This
+makes it snappier to develop in Chrome, but it may look sub-optimal in other
+browsers. */ -}}
+
+{{ if eq .Site.Language.Direction "rtl" -}}
+  {{ $css = $css
+      | postCSS (dict "use" "autoprefixer rtlcss" "noMap" true)
+      | resources.Copy (replace $scssMain "." ".rtl.") -}}
+{{ else if hugo.IsProduction -}}
+  {{ $css = $css | postCSS -}}
+{{ end -}}
+
+{{ if hugo.IsProduction -}}
+  {{ $css = $css | minify | fingerprint -}}
+  <link rel="preload" href="{{ $css.RelPermalink }}" as="style" integrity="{{ $css.Data.Integrity }}" crossorigin="anonymous">
+{{ end -}}
+
+{{ with $css -}}
+  <link href="{{ .RelPermalink }}" rel="stylesheet"
+  {{- with .Data.Integrity }} integrity="{{ . }}" crossorigin="anonymous"{{ end -}}
+  >
+{{ else -}}
+  {{ errorf "Resource not found or error building CSS: %s" $scssMain -}}
+{{ end -}}
+
+{{- /**/ -}}

--- a/docs/layouts/baseof.html
+++ b/docs/layouts/baseof.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.Direction }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
+    class="no-js"
+    {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+    {{- if $darkMode.enable }} data-theme-init{{ end }}>
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    <header>
+      {{ partial "navbar.html" . }}
+    </header>
+    <div class="container-fluid td-default td-outer">
+      <main role="main" class="td-main">
+        {{ block "main" . }}{{ end }}
+      </main>
+      {{ partial "footer.html" . }}
+    </div>
+    {{ partialCached "scripts.html" . }}
+  </body>
+</html>

--- a/docs/layouts/baseof.html
+++ b/docs/layouts/baseof.html
@@ -3,7 +3,7 @@
     {{- with .Site.Language.Direction }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
     class="no-js"
-    {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+    {{- $darkMode := partialCached "dark-mode-config.html" . "dark-mode-global" -}}
     {{- if $darkMode.enable }} data-theme-init{{ end }}>
   <head>
     {{ partial "head.html" . }}

--- a/docs/layouts/docs/baseof.html
+++ b/docs/layouts/docs/baseof.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html itemscope itemtype="http://schema.org/WebPage"
-    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{- with .Site.Language.Direction }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
     class="no-js"
     {{- $darkMode := partialCached "dark-mode-config.html" . "dark-mode-global" -}}

--- a/docs/layouts/shortcodes/glossary-terms.html
+++ b/docs/layouts/shortcodes/glossary-terms.html
@@ -5,7 +5,7 @@
   Used on the glossary page to display the complete term list.
 */}}
 
-{{ $glossary := site.Data.glossary }}
+{{ $glossary := hugo.Data.glossary }}
 
 {{ if $glossary.terms }}
   {{ range $glossary.terms }}

--- a/docs/layouts/shortcodes/term.html
+++ b/docs/layouts/shortcodes/term.html
@@ -27,7 +27,7 @@
 {{ end }}
 
 {{/* Look up the term in glossary data */}}
-{{ $glossary := site.Data.glossary }}
+{{ $glossary := hugo.Data.glossary }}
 {{ $termData := false }}
 
 {{ if $glossary.terms }}

--- a/docs/shared-content/installation/drasi-server/build-from-source-prereqs.md
+++ b/docs/shared-content/installation/drasi-server/build-from-source-prereqs.md
@@ -36,7 +36,7 @@ export JQ_LIB_DIR="/usr/lib/$(uname -m)-linux-gnu"
 
 Building natively on Windows requires the Visual Studio 2022 Build Tools (for the MSVC toolchain):
 
-```powershell
+```powershell {#windows-native-deps}
 winget install --id Microsoft.VisualStudio.2022.BuildTools -e `
     --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
 ```

--- a/docs/shared-content/installation/drasi-server/build-from-source-prereqs.md
+++ b/docs/shared-content/installation/drasi-server/build-from-source-prereqs.md
@@ -11,10 +11,11 @@ Then install the remaining dependencies with Homebrew:
 brew install protobuf jq oniguruma
 ```
 
-The build links against `libjq`, but the `jq-sys` crate cannot locate the Homebrew copy automatically and the build fails with `Unable to find libjq` unless you tell it where the library is. Set `JQ_LIB_DIR` in the same terminal you build from (add it to your shell profile to make it permanent):
+The build links against Homebrew's `libjq` and `libonig`, but these are not on the compiler's default search path (on Apple Silicon, Homebrew installs under `/opt/homebrew`), so the build fails with `Unable to find libjq` or `ld: library 'onig' not found` unless you point the toolchain at them. Set the following in the same terminal you build from (add them to your shell profile to make them permanent):
 
 ```bash {#macos-jq-lib-dir}
 export JQ_LIB_DIR="$(brew --prefix jq)/lib"
+export LIBRARY_PATH="$(brew --prefix jq)/lib:$(brew --prefix oniguruma)/lib:${LIBRARY_PATH:-}"
 ```
 
 #### Debian / Ubuntu
@@ -23,6 +24,12 @@ export JQ_LIB_DIR="$(brew --prefix jq)/lib"
 
 ```bash {#linux-native-deps}
 sudo apt-get install -y libssl-dev pkg-config clang libclang-dev libjq-dev libonig-dev protobuf-compiler 
+```
+
+The `libjq-dev` package does not ship a pkg-config file, so the `jq-sys` crate cannot locate `libjq` automatically and the build fails with `Unable to find libjq` unless you tell it where the library is. Set `JQ_LIB_DIR` to your architecture's multiarch library directory in the same terminal you build from (add it to your shell profile to make it permanent):
+
+```bash {#linux-jq-lib-dir}
+export JQ_LIB_DIR="/usr/lib/$(uname -m)-linux-gnu"
 ```
 
 #### Windows

--- a/docs/shared-content/installation/drasi-server/build-from-source-prereqs.md
+++ b/docs/shared-content/installation/drasi-server/build-from-source-prereqs.md
@@ -37,7 +37,8 @@ export JQ_LIB_DIR="/usr/lib/$(uname -m)-linux-gnu"
 Building natively on Windows requires the Visual Studio 2022 Build Tools (for the MSVC toolchain):
 
 ```powershell {#windows-native-deps}
-winget install --id Microsoft.VisualStudio.2022.BuildTools -e `
+winget install --id Microsoft.VisualStudio.2022.BuildTools -e --source winget `
+    --accept-source-agreements --accept-package-agreements --disable-interactivity `
     --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
 ```
 

--- a/docs/shared-content/installation/drasi-server/build-from-source-prereqs.md
+++ b/docs/shared-content/installation/drasi-server/build-from-source-prereqs.md
@@ -7,16 +7,21 @@ Install Xcode Command Line Tools to get `clang` and `perl`.
 
 Then install the remaining dependencies with Homebrew:
 
-```bash
-brew install protobuf
-brew install jq
+```bash {#macos-native-deps}
+brew install protobuf jq oniguruma
+```
+
+The build links against `libjq`, but the `jq-sys` crate cannot locate the Homebrew copy automatically and the build fails with `Unable to find libjq` unless you tell it where the library is. Set `JQ_LIB_DIR` in the same terminal you build from (add it to your shell profile to make it permanent):
+
+```bash {#macos-jq-lib-dir}
+export JQ_LIB_DIR="$(brew --prefix jq)/lib"
 ```
 
 #### Debian / Ubuntu
 
 `perl` is pre-installed. Install everything else with:
 
-```bash
+```bash {#linux-native-deps}
 sudo apt-get install -y libssl-dev pkg-config clang libclang-dev libjq-dev libonig-dev protobuf-compiler 
 ```
 
@@ -32,5 +37,5 @@ winget install --id Microsoft.VisualStudio.2022.BuildTools -e `
 Then install the pinned Rust MSVC toolchain:
 
 ```powershell
-rustup toolchain install 1.88.0-x86_64-pc-windows-msvc
+rustup toolchain install 1.95.0-x86_64-pc-windows-msvc
 ```

--- a/docs/shared-content/installation/drasi-server/download-binary.md
+++ b/docs/shared-content/installation/drasi-server/download-binary.md
@@ -51,6 +51,6 @@ You should see output showing the version number. The exact version depends on w
 
 ```text
 drasi-server 0.2.1
-rustc: rustc 1.88.0 (6b00bc388 2025-06-23)
+rustc: rustc 1.95.0
 plugin-sdk: 0.9.1
 ```

--- a/docs/shared-content/installation/drasi-server/download-binary.md
+++ b/docs/shared-content/installation/drasi-server/download-binary.md
@@ -22,13 +22,13 @@ curl -fsSL https://github.com/drasi-project/drasi-server/releases/latest/downloa
 chmod +x bin/drasi-server
 {{< /tab >}}
 {{< tab header="Linux musl (x64)" lang="bash" >}}
-apk add --no-cache libstdc++ libgcc
+apk add --no-cache libstdc++ libgcc curl
 mkdir -p bin
 curl -fsSL https://github.com/drasi-project/drasi-server/releases/latest/download/drasi-server-x86_64-linux-musl -o bin/drasi-server
 chmod +x bin/drasi-server
 {{< /tab >}}
 {{< tab header="Linux musl (ARM64)" lang="bash" >}}
-apk add --no-cache libstdc++ libgcc
+apk add --no-cache libstdc++ libgcc curl
 mkdir -p bin
 curl -fsSL https://github.com/drasi-project/drasi-server/releases/latest/download/drasi-server-aarch64-linux-musl -o bin/drasi-server
 chmod +x bin/drasi-server
@@ -43,7 +43,7 @@ Invoke-WebRequest -Uri "https://github.com/drasi-project/drasi-server/releases/l
 
 Verify the binary works:
 
-```bash
+```bash {#verify-download}
 ./bin/drasi-server --version
 ```
 


### PR DESCRIPTION
# Description

Reworks the Drasi Server **Build from Source** installation path into a documented, install-based flow and adds CI that verifies the documented commands actually work across platforms. Also mounts the remaining Drasi Server tutorials into the site and clears Hugo deprecation warnings.

> Note: the corresponding tutorial content changes in `learning-drasi-server` (adding a "Build from Source" option to each tutorial) ship in a **separate PR**. We should merge in https://github.com/drasi-project/learning-drasi-server/pull/9/ first

## Changes

### Installation guides
- **Build from Source** (`docs/content/drasi-server/how-to-guides/installation/build-from-source/_index.md`): switched from raw `cargo build`/`cargo run` to `cargo install --path . --root .` producing a stable `./bin/drasi-server`; bumped the required Rust to **1.95+**; added verify steps and an "iterating on source" tip. Tagged the documented code fences with stable ids (`clone-drasi-server`, `build-drasi-server`, `verify-drasi-server`) so CI can extract them.
- **Native prerequisites** (`docs/shared-content/installation/drasi-server/build-from-source-prereqs.md`): added a stable id to the Windows block and made the `winget` command non-interactive (`--source winget`, `--accept-*-agreements`, `--disable-interactivity`) so it works unattended.
- **New: Install the SSE CLI** (`docs/content/drasi-server/how-to-guides/installation/install-sse-cli/_index.md`): prebuilt-binary and build-from-source options, with `build-sse-cli` / `verify-sse-cli` snippet ids.
- Added an **SSE CLI** card to the installation index (`docs/content/drasi-server/how-to-guides/installation/_index.md`) and a minor tweak to `docs/shared-content/installation/drasi-server/download-binary.md`.

### CI: verify the guide never drifts
- **New workflow** (`.github/workflows/verify-build-from-source.yml`): runs the *documented* commands (extracted at build time, never hardcoded) on a matrix of **Linux, macOS (Apple Silicon), macOS (Intel, `macos-26-intel`), and Windows**. Windows uses a dedicated PowerShell step. Triggers on PR (to the guide/script), manual dispatch, and a weekly schedule.
- **Scheduled-failure issue**: a `report-failure` job opens (or comments on) a tracking issue **only when the scheduled run fails**, so upstream `drasi-server` drift doesn't go unnoticed.
- **New extraction script** (`.github/scripts/extract-doc-commands.js`): pulls commands from the Markdown by fenced-code-block id, with a `linux` / `macos` / `windows` manifest.

### Docs site
- Mounted the remaining Drasi Server tutorials (**Building Comfort, High Risk Containers, Curbside Pickup**) from the `learning-drasi-server` module in `docs/config.toml` so they render in the site nav (previously only *Getting Started* was mounted).

### Hugo deprecation fixes
- `.Language.LanguageDirection` → `.Language.Direction` in `docs/layouts/docs/baseof.html`, plus project overrides of the theme's `docs/layouts/baseof.html` and `docs/layouts/_partials/head-css.html` (docsy is a pinned submodule).
- `.Site.Data` → `hugo.Data` in `docs/layouts/shortcodes/glossary-terms.html` and `docs/layouts/shortcodes/term.html`.
- `languages.en.languageName` → `label` in `docs/config.toml`.

Build now reports **0 deprecation warnings**.


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #260  #259 
